### PR TITLE
Tillate ulike jobbtyper å kjøre samtidig på samme behandling

### DIFF
--- a/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
@@ -72,12 +72,12 @@ internal class JobbRepository(private val connection: DBConnection) {
          */
         val query = """
             with ekskluderende_jobb as (
-                select distinct on (sak_id, behandling_id) id, status, neste_kjoring
+                select distinct on (sak_id, behandling_id, type) id, status, neste_kjoring
                 from jobb
                 where status IN ('${JobbStatus.FEILET.name}', '${JobbStatus.KLAR.name}')
                   and (sak_id is not null or (sak_id is null and behandling_id is not null))
                   and neste_kjoring < ?
-                order by sak_id, behandling_id, neste_kjoring asc
+                order by sak_id, behandling_id, type, neste_kjoring asc
             ),
             klar_ekskluderende_jobb as (
                 select id, neste_kjoring

--- a/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
@@ -151,7 +151,9 @@ class MotorTest {
             }
         }
 
-        // Verifiser at vi faktisk kjører på flere kjerner
+        // Verifiser at vi faktisk kjører på flere kjerner - dette fungerer ikke nå fordi det ligger en Thread.sleep(500)
+        // som blokkerer alle andre forbrenningskammer enn den som først starter å konsumere dersom de ikke får resultat
+        // når plukkJobb kalles. Burde se på en løsning for å konfigurere dette.
         //assertThat(resultat.map { it.trådNavn }.toSet().size).isGreaterThan(1)
         assertThat(resultat.map { it.opprettet }).isSorted()
         assertThat(resultat.map { it.value }.map { it.toInt() }).isSorted()

--- a/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
@@ -152,7 +152,7 @@ class MotorTest {
         }
 
         // Verifiser at vi faktisk kjører på flere kjerner
-        assertThat(resultat.map { it.trådNavn }.toSet().size).isGreaterThan(1)
+        //assertThat(resultat.map { it.trådNavn }.toSet().size).isGreaterThan(1)
         assertThat(resultat.map { it.opprettet }).isSorted()
         assertThat(resultat.map { it.value }.map { it.toInt() }).isSorted()
 

--- a/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
@@ -2,9 +2,11 @@ package no.nav.aap.motor
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.dbconnect.Row
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.InitTestDatabase
 import no.nav.aap.motor.help.RekkefølgeTestJobbUtfører
+import no.nav.aap.motor.help.EnAnnenRekkefølgeTestJobbUtfører
 import no.nav.aap.motor.help.TullTestJobbUtfører
 import no.nav.aap.motor.mdc.NoExtraLogInfoProvider
 import no.nav.aap.motor.testutil.TestUtil
@@ -143,20 +145,72 @@ class MotorTest {
 
         assertThat(svare).isEqualTo(100L)
 
-        val innsattData = dataSource.transaction {
+        val resultat = dataSource.transaction {
             it.queryList("SELECT value, trad_navn, opprettet_tid FROM ORDER_TABLE ORDER BY opprettet_tid") {
-                setRowMapper {
-                    Triple(it.getString("trad_navn"), it.getLocalDateTime("OPPRETTET_TID"), it.getString("value"))
-                }
+                setRowMapper(mapOrderResultat())
             }
         }
 
-        // Verifiser at vi faktisk kjører på to kjerner
-        //assertThat(innsattData.map { it.first }.toSet().size).isGreaterThan(1)
-        assertThat(innsattData.map { it.second }).isSorted()
-        assertThat(innsattData.map { it.third }.map { it.toInt() }).isSorted()
+        // Verifiser at vi faktisk kjører på flere kjerner
+        assertThat(resultat.map { it.trådNavn }.toSet().size).isGreaterThan(1)
+        assertThat(resultat.map { it.opprettet }).isSorted()
+        assertThat(resultat.map { it.value }.map { it.toInt() }).isSorted()
 
         motor.stop()
+    }
+
+    @Test
+    fun `skal kunne prosessere jobber som håndterer samme behandling samtidig hvis jobb er av ulik type`() {
+        val separator = "|"
+        val jobb1 = RekkefølgeTestJobbUtfører
+        val jobb2 = EnAnnenRekkefølgeTestJobbUtfører
+
+        val motor = Motor(
+            dataSource = dataSource,
+            antallKammer = 5,
+            logInfoProvider = NoExtraLogInfoProvider,
+            jobber = listOf(jobb1, jobb2)
+        )
+
+        // Oppretter oppgaver for både jobb1 og for jobb2
+        dataSource.transaction { conn ->
+            (1..50).forEach { counter ->
+                JobbRepository(conn).leggTil(
+                    JobbInput(jobb1).medPayload("${jobb1.navn}$separator$counter").forBehandling(0, 1)
+                )
+            }
+            (51..100).forEach { counter ->
+                JobbRepository(conn).leggTil(
+                    JobbInput(jobb2).medPayload("${jobb2.navn}$separator$counter").forBehandling(0, 1)
+                )
+            }
+        }
+
+        motor.start()
+
+        util.ventPåSvar()
+
+        motor.stop()
+
+        val resultat = dataSource.transaction {
+            it.queryList("SELECT value, trad_navn, opprettet_tid FROM ORDER_TABLE ORDER BY opprettet_tid") {
+                setRowMapper(mapOrderResultat())
+            }
+        }
+
+        // Verifisere at alle opprettede jobber er prosessert
+        assertThat(resultat.size).isEqualTo(100L)
+
+        // Verifiser at vi faktisk kjørte på flere kjerner ved å sjekke distinkte trådnavn
+        assertThat(resultat.map { it.trådNavn }.toSet().size).isGreaterThan(1)
+
+        // Sjekker at hver jobbtype kjører i rekkefølge når de er gruppert innenfor en behandling
+        assertThat(resultat.filter { it.value.startsWith(jobb1.navn) }.map { it.value.split(separator)[1].toInt()} ).isSorted()
+        assertThat(resultat.filter { it.value.startsWith(jobb2.navn) }.map { it.value.split(separator)[1].toInt() }).isSorted()
+
+        // Sjekker så at de to jobbtypene prosesseres om hverandre og at resultatet i helhet derfor ikke er sortert
+        val values = resultat.map { it.value.split(separator)[1].toInt() }
+        assertThat(values).isNotEqualTo(values.sorted())
     }
 
     // Har timeout her for å feile om ting begynner å ta tid
@@ -206,5 +260,15 @@ class MotorTest {
         logger.info("Waited $timeInMillis millis.")
         return requireNotNull(res)
     }
+
+    private fun mapOrderResultat(): (Row) -> OrderResultat = { row ->
+        OrderResultat(
+            value = row.getString("value"),
+            opprettet = row.getLocalDateTime("opprettet_tid"),
+            trådNavn = row.getString("trad_navn"),
+        )
+    }
+
+    private data class OrderResultat(val value: String, val opprettet: LocalDateTime, val trådNavn: String)
 
 }

--- a/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
@@ -172,16 +172,20 @@ class MotorTest {
             jobber = listOf(jobb1, jobb2)
         )
 
+        var nesteKjøring = LocalDateTime.now().minusDays(1)
+
         // Oppretter oppgaver for både jobb1 og for jobb2
         dataSource.transaction { conn ->
             (1..50).forEach { counter ->
+                nesteKjøring = nesteKjøring.plusSeconds(1)
                 JobbRepository(conn).leggTil(
-                    JobbInput(jobb1).medPayload("${jobb1.navn}$separator$counter").forBehandling(0, 1)
+                    JobbInput(jobb1).medPayload("${jobb1.navn}$separator$counter").medNesteKjøring(nesteKjøring).forBehandling(0, 1)
                 )
             }
             (51..100).forEach { counter ->
+                nesteKjøring = nesteKjøring.plusSeconds(1)
                 JobbRepository(conn).leggTil(
-                    JobbInput(jobb2).medPayload("${jobb2.navn}$separator$counter").forBehandling(0, 1)
+                    JobbInput(jobb2).medPayload("${jobb2.navn}$separator$counter").medNesteKjøring(nesteKjøring).forBehandling(0, 1)
                 )
             }
         }

--- a/motor/src/test/kotlin/no/nav/aap/motor/help/EnAnnenRekkefølgeTestJobbUtfører.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/help/EnAnnenRekkefølgeTestJobbUtfører.kt
@@ -1,0 +1,26 @@
+package no.nav.aap.motor.help
+
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.motor.Jobb
+import no.nav.aap.motor.JobbUtfører
+
+class EnAnnenRekkefølgeTestJobbUtfører(connection: DBConnection) : RekkefølgeTestJobbUtfører(connection) {
+
+    companion object : Jobb {
+        override fun konstruer(connection: DBConnection): JobbUtfører {
+            return EnAnnenRekkefølgeTestJobbUtfører(connection)
+        }
+
+        override fun type(): String {
+            return "EnAnnenTullRekkefolge"
+        }
+
+        override fun navn(): String {
+            return "EnAnnenTullRekkefolge"
+        }
+
+        override fun beskrivelse(): String {
+            return "EnAnnenTullRekkefolge"
+        }
+    }
+}

--- a/motor/src/test/kotlin/no/nav/aap/motor/help/RekkefølgeTestJobbUtfører.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/help/RekkefølgeTestJobbUtfører.kt
@@ -6,7 +6,7 @@ import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.JobbUtfører
 import org.slf4j.LoggerFactory
 
-class RekkefølgeTestJobbUtfører(private val connection: DBConnection) : JobbUtfører {
+open class RekkefølgeTestJobbUtfører(private val connection: DBConnection) : JobbUtfører {
 
     private val logger = LoggerFactory.getLogger(TullTestJobbUtfører::class.java)
 


### PR DESCRIPTION
For hver jobbtype, når det er angitt en behandling, så skal dette prosesseres i rekkefølge. Hvis flere jobbtyper ønsker å prosessere samme behandling samtidig skal dette være mulig, men da i rekkefølge innenfor hver jobbtype.