### PR TITLE
Ved plukk av neste jobb kjøres union mellom jobber med sak/behandling…

### DIFF
--- a/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
@@ -94,7 +94,7 @@ public class JobbRepository(private val connection: DBConnection) {
             ),
             jobb_kandidat as (
                 (select * from klar_ekskluderende_jobb)
-                union
+                union ALL
                 (select * from klar_selvstendig_jobb)
             )
 


### PR DESCRIPTION
… og jobber uten sak/behandling - da er union all mer effektivt, ettersom den ikke utfører duplikatsjekk underveis