### PR TITLE
Kortere default connection timeout

### DIFF
--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/ClientConfig.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/ClientConfig.kt
@@ -5,7 +5,7 @@ import java.time.Duration
 
 public class ClientConfig(
     internal val scope: String? = null,
-    internal val connectionTimeout: Duration = Duration.ofSeconds(15),
+    internal val connectionTimeout: Duration = Duration.ofSeconds(2),
     internal val additionalHeaders: List<Header> = emptyList(),
     internal val additionalFunctionalHeaders: List<FunctionalHeader> = emptyList()
 )


### PR DESCRIPTION
Bør ikke ha for lang connection-timeout - det kan gi risiko for at ma…n spiser og holder på for mange connections for lenge, helt unødvendig. Ingen av våre normale kall bør bruke mer enn noen hundre millisekunder på å opprette en connection