### PR TITLE
Retry feilede jobber sjeldnere

### DIFF
--- a/motor/src/main/kotlin/no/nav/aap/motor/retry/RekjørFeiledeJobb.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/retry/RekjørFeiledeJobb.kt
@@ -30,7 +30,7 @@ internal class RekjørFeiledeJobb(private val repository: RetryFeiledeJobberRepo
         override val beskrivelse =
             "Finner feilende jobber og markerer disse som klar for nytt forsøk ved hver kjøring av denne jobben."
 
-        override val cron = CronExpression.create("0 0,15,30,45 7-17,20 * * *")
+        override val cron = CronExpression.create("0 0 7,12,15,20 * * *")
 
     }
 }

--- a/motor/src/main/kotlin/no/nav/aap/motor/retry/RekjørFeiledeJobb.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/retry/RekjørFeiledeJobb.kt
@@ -30,6 +30,9 @@ internal class RekjørFeiledeJobb(private val repository: RetryFeiledeJobberRepo
         override val beskrivelse =
             "Finner feilende jobber og markerer disse som klar for nytt forsøk ved hver kjøring av denne jobben."
 
+        /**
+         * Hver dag kl 07:00, 12:00, 15:00 og 20:00
+         */
         override val cron = CronExpression.create("0 0 7,12,15,20 * * *")
 
     }


### PR DESCRIPTION
Når vi rekjører feilede jobber hvert kvarter bruker vi unødig mye kap…asitet til å reprosessere samme feil om igjen. Ved å kjøre sjeldnere vil det trolig oppleves mer stabilt for saksbehandlere