### PR TITLE
Bytt til Texas for token exchange

### DIFF
--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/TexasTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/TexasTokenProvider.kt
@@ -1,0 +1,37 @@
+package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider
+
+import io.micrometer.core.instrument.MeterRegistry
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.post
+import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
+import java.net.URI
+
+/** Tokenprovider som benytter [Texas](https://doc.nais.io/auth/explanations/#texas). */
+public class TexasTokenProvider(
+    private val identityProvider: String,
+    texasUri: URI? = null,
+    private val prometheus: MeterRegistry,
+): TokenProvider {
+    private val texasUri = texasUri ?: URI(requiredConfigForKey("nais.token.exchange.endpoint"))
+
+    private val client = RestClient.withDefaultResponseHandler(
+        config = ClientConfig(),
+        tokenProvider = NoTokenTokenProvider(),
+        prometheus = prometheus,
+    )
+
+    override fun getToken(scope: String?, currentToken: OidcToken?): OidcToken {
+        if (scope == null) throw IllegalArgumentException("scope må være definert for token exchange med texas")
+        if (currentToken == null) throw IllegalArgumentException("token må være tilstede for token exchange for texas")
+
+        val response: OidcTokenResponse = client.post(texasUri, PostRequest(body = mapOf(
+            "identity_provider" to identityProvider,
+            "target" to scope,
+            "user_token" to currentToken.token(),
+        ))) ?: error("oidc-token-response forventet fra texas")
+
+        return OidcToken(response.access_token)
+    }
+}

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/AzureOBOTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/AzureOBOTokenProvider.kt
@@ -1,0 +1,17 @@
+package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasTokenProvider
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
+import java.net.URI
+
+public class AzureOBOTokenProvider(
+    texasUri: URI = URI(requiredConfigForKey("nais.token.exchange.endpoint")),
+    prometheus: MeterRegistry = SimpleMeterRegistry(),
+) : TokenProvider by TexasTokenProvider(
+    texasUri = texasUri,
+    identityProvider = "azuread",
+    prometheus = prometheus,
+)

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/OnBehalfOfTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/OnBehalfOfTokenProvider.kt
@@ -10,12 +10,19 @@ import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.NoTokenTokenPr
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcTokenResponse
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
+import no.nav.aap.komponenter.miljo.Miljø
 import java.net.URLEncoder
 import java.time.Duration
 import kotlin.text.Charsets.UTF_8
 
-public object OnBehalfOfTokenProvider : TokenProvider {
+@Deprecated("Bruk AzureOBOTokenProvider eller ClientCredentialsTokenProvider")
+public object OnBehalfOfTokenProvider : TokenProvider by
+if (Miljø.erProd())
+    GammelOnBehalfOfTokenProvider
+else
+    AzureOBOTokenProvider()
 
+private object GammelOnBehalfOfTokenProvider : TokenProvider {
     private val client = RestClient.withDefaultResponseHandler(
         config = ClientConfig(),
         tokenProvider = NoTokenTokenProvider(),
@@ -59,6 +66,6 @@ public object OnBehalfOfTokenProvider : TokenProvider {
                 "&client_secret=" + config.clientSecret +
                 "&assertion=" + oidcToken.token() +
                 "&scope=" + encodedScope +
-                "&requested_token_use=on_behalf_of";
+                "&requested_token_use=on_behalf_of"
     }
 }

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/OnBehalfOfTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/OnBehalfOfTokenProvider.kt
@@ -1,36 +1,4 @@
 package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx
 
-import no.nav.aap.komponenter.config.requiredConfigForKey
-import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
-import no.nav.aap.komponenter.httpklient.httpclient.RestClient
-import no.nav.aap.komponenter.httpklient.httpclient.post
-import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.NoTokenTokenProvider
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcTokenResponse
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
-import java.net.URI
-import kotlin.IllegalArgumentException
-
-public class OnBehalfOfTokenProvider(
-    private val texasUri: URI = URI(requiredConfigForKey("nais.token.exchange.endpoint")),
-    private val identityProvider: String = "tokenx"
-): TokenProvider {
-    private val client = RestClient.withDefaultResponseHandler(
-        config = ClientConfig(),
-        tokenProvider = NoTokenTokenProvider(),
-    )
-
-    override fun getToken(scope: String?, currentToken: OidcToken?): OidcToken {
-        if (scope == null) throw IllegalArgumentException("scope må være definert for tokenx")
-        if (currentToken == null) throw IllegalArgumentException("token må være tilstede for tokenx")
-
-        val response: OidcTokenResponse = client.post(texasUri, PostRequest(body = mapOf(
-            "identity_provider" to identityProvider,
-            "target" to scope,
-            "user_token" to currentToken.token(),
-        ))) ?: error("oidc-token-response forventet fra texas")
-
-        return OidcToken(response.access_token)
-    }
-}
+@Deprecated("Brukt TokenxOBOTokenProvider")
+public typealias OnBehalfOfTokenProvider = TokenxOBOTokenProvider

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/TokenxOBOTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/TokenxOBOTokenProvider.kt
@@ -1,0 +1,17 @@
+package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasTokenProvider
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
+import java.net.URI
+
+public class TokenxOBOTokenProvider(
+    texasUri: URI = URI(requiredConfigForKey("nais.token.exchange.endpoint")),
+    prometheus: MeterRegistry = SimpleMeterRegistry(),
+) : TokenProvider by TexasTokenProvider(
+    texasUri = texasUri,
+    identityProvider = "tokenx",
+    prometheus = prometheus,
+)


### PR DESCRIPTION
Exchange tar typisk 300 ms. Texas med cachen hit tar 300 µs. Exchange skjer i kall mellom alle mikrotjenester (oppgave, tilgang, pip, dokumentinnhenting, pdl, osv), så her kan vi spare sekunder når en flate lastes i Kelvin.

Tar også og gir forskjellig navn på klassene for obo-tokens for ansatt og bruker.