### PR TITLE
Fiks ubrukte parametere i ktor-openapi-generator

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -36,11 +36,10 @@ comments:
   active: true
   AbsentOrWrongFileLicense:
     active: false
-    licenseTemplateFile: 'license.template'
     licenseTemplateIsRegex: false
-  CommentOverPrivateFunction:
+  DocumentationOverPrivateFunction:
     active: false
-  CommentOverPrivateProperty:
+  DocumentationOverPrivateProperty:
     active: false
   DeprecatedBlockTag:
     active: false
@@ -629,8 +628,6 @@ style:
     allowedPatterns: ''
   ForbiddenImport:
     active: false
-    imports: []
-    forbiddenPatterns: ''
   ForbiddenMethodCall:
     active: false
     methods:
@@ -766,8 +763,6 @@ style:
     active: false
     acceptableLength: 4
     allowNonStandardGrouping: false
-  UnnecessaryAnnotationUseSiteTarget:
-    active: false
   UnnecessaryAny:
     active: false
   UnnecessaryApply:

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/Throws.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/Throws.kt
@@ -20,7 +20,7 @@ data class ThrowsInfo(override val exceptions: List<APIException<*, *>>) : Throw
 /**
  * exists for simpler syntax
  */
-inline fun <T: OpenAPIRoute<T>, reified EX : Throwable> T.throws(status: HttpStatusCode, exClass: KClass<EX>, crossinline fn: T.() -> Unit = {}): T {
+inline fun <T: OpenAPIRoute<T>, reified EX : Throwable> T.throws(status: HttpStatusCode, @Suppress("UNUSED_PARAMETER") exClass: KClass<EX>, crossinline fn: T.() -> Unit = {}): T {
     return throws<T, EX>(status, fn)
 }
 
@@ -31,7 +31,7 @@ inline fun <T: OpenAPIRoute<T>, reified EX : Throwable> T.throws(status: HttpSta
 /**
  * exists for simpler syntax
  */
-inline fun <T: OpenAPIRoute<T>, reified EX : Throwable, reified B> T.throws(status: HttpStatusCode, example: B? = null, exClass: KClass<EX>, crossinline fn: T.() -> Unit = {}): T {
+inline fun <T: OpenAPIRoute<T>, reified EX : Throwable, reified B> T.throws(status: HttpStatusCode, example: B? = null, @Suppress("UNUSED_PARAMETER") exClass: KClass<EX>, crossinline fn: T.() -> Unit = {}): T {
     return throws<T, EX, B>(status, example, null, fn)
 }
 


### PR DESCRIPTION
## Endringer

### Throws.kt
Lagt til `@Suppress("UNUSED_PARAMETER")` på `exClass`-parametrene i to overloads i `Throws.kt`. Parameterne eksisterer utelukkende for å forenkle syntaks (type-inferens), og er bevisst ubrukte i funksjonskroppen. Kommentaren *«exists for simpler syntax»* i koden bekrefter intensjonen.

### detekt.yml
Oppdatert konfigurasjon for kompatibilitet med detekt 2.0.0-alpha.2:
- Fjernet ugyldig `licenseTemplateFile`-egenskap fra `AbsentOrWrongFileLicense`
- Omdøpt `CommentOverPrivateFunction`/`CommentOverPrivateProperty` til `DocumentationOverPrivateFunction`/`DocumentationOverPrivateProperty`
- Fjernet ugyldige `imports` og `forbiddenPatterns` fra `ForbiddenImport`
- Fjernet fjernet regel `UnnecessaryAnnotationUseSiteTarget`