### PR TITLE
AAP-1919 Legge til Texas M2M

### DIFF
--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/TexasM2MTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/TexasM2MTokenProvider.kt
@@ -1,0 +1,43 @@
+package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider
+
+import io.micrometer.core.instrument.MeterRegistry
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.post
+import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
+import java.net.URI
+
+/**
+ * Tokenprovider som benytter [Texas](https://doc.nais.io/auth/explanations/#texas).
+ *
+ * [How to consume M2M](https://docs.nais.io/auth/entra-id/how-to/consume-m2m)
+ **/
+public class TexasM2MTokenProvider(
+    private val identityProvider: String,
+    texasUri: URI? = null,
+    private val prometheus: MeterRegistry,
+) : TokenProvider {
+    private val texasUri = texasUri ?: URI(requiredConfigForKey("nais.token.endpoint"))
+
+    private val client = RestClient.withDefaultResponseHandler(
+        config = ClientConfig(),
+        tokenProvider = NoTokenTokenProvider(),
+        prometheus = prometheus,
+    )
+
+    override fun getToken(scope: String?, currentToken: OidcToken?): OidcToken {
+        requireNotNull(scope) { "scope må være definert for token exchange med texas" }
+
+        val response: OidcTokenResponse = client.post(
+            texasUri, PostRequest(
+                body = mapOf(
+                    "identity_provider" to identityProvider,
+                    "target" to scope,
+                )
+            )
+        ) ?: error("oidc-token-response forventet fra texas")
+
+        return OidcToken(response.access_token)
+    }
+}

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/TexasOBOTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/TexasOBOTokenProvider.kt
@@ -8,12 +8,16 @@ import no.nav.aap.komponenter.httpklient.httpclient.post
 import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
 import java.net.URI
 
-/** Tokenprovider som benytter [Texas](https://doc.nais.io/auth/explanations/#texas). */
-public class TexasTokenProvider(
+/**
+ * Tokenprovider som benytter [Texas](https://doc.nais.io/auth/explanations/#texas).
+ *
+ * [How to consume OBO](https://docs.nais.io/auth/entra-id/how-to/consume-obo)
+ **/
+public class TexasOBOTokenProvider(
     private val identityProvider: String,
     texasUri: URI? = null,
     private val prometheus: MeterRegistry,
-): TokenProvider {
+) : TokenProvider {
     private val texasUri = texasUri ?: URI(requiredConfigForKey("nais.token.exchange.endpoint"))
 
     private val client = RestClient.withDefaultResponseHandler(
@@ -23,14 +27,18 @@ public class TexasTokenProvider(
     )
 
     override fun getToken(scope: String?, currentToken: OidcToken?): OidcToken {
-        if (scope == null) throw IllegalArgumentException("scope må være definert for token exchange med texas")
-        if (currentToken == null) throw IllegalArgumentException("token må være tilstede for token exchange for texas")
+        requireNotNull(scope) { "scope må være definert for token exchange med texas" }
+        requireNotNull(currentToken) { "token må være tilstede for token exchange for texas" }
 
-        val response: OidcTokenResponse = client.post(texasUri, PostRequest(body = mapOf(
-            "identity_provider" to identityProvider,
-            "target" to scope,
-            "user_token" to currentToken.token(),
-        ))) ?: error("oidc-token-response forventet fra texas")
+        val response: OidcTokenResponse = client.post(
+            texasUri, PostRequest(
+                body = mapOf(
+                    "identity_provider" to identityProvider,
+                    "target" to scope,
+                    "user_token" to currentToken.token(),
+                )
+            )
+        ) ?: error("oidc-token-response forventet fra texas")
 
         return OidcToken(response.access_token)
     }

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/AzureM2MTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/AzureM2MTokenProvider.kt
@@ -3,14 +3,14 @@ package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.komponenter.config.requiredConfigForKey
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasOBOTokenProvider
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasM2MTokenProvider
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
 import java.net.URI
 
-public class AzureOBOTokenProvider(
-    texasUri: URI = URI(requiredConfigForKey("nais.token.exchange.endpoint")),
+public class AzureM2MTokenProvider(
+    texasUri: URI = URI(requiredConfigForKey("nais.token.endpoint")),
     prometheus: MeterRegistry = SimpleMeterRegistry(),
-) : TokenProvider by TexasOBOTokenProvider(
+) : TokenProvider by TexasM2MTokenProvider(
     texasUri = texasUri,
     identityProvider = "entra_id",
     prometheus = prometheus,

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/ClientCredentialsTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/ClientCredentialsTokenProvider.kt
@@ -10,16 +10,24 @@ import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.NoTokenTokenPr
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcTokenResponse
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
+import no.nav.aap.komponenter.miljo.Miljø
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URLEncoder
 import java.time.Duration
 import java.time.LocalDateTime
+import kotlin.jvm.java
 import kotlin.text.Charsets.UTF_8
 
-public object ClientCredentialsTokenProvider : TokenProvider {
+@Deprecated("Bruk AzureM2MTokenProvider")
+public object ClientCredentialsTokenProvider : TokenProvider by
+if (Miljø.erProd() || Miljø.erDev() || Miljø.erLokal())
+    GammelClientCredentialsTokenProvider
+else
+    AzureM2MTokenProvider()
 
-    private val log: Logger = LoggerFactory.getLogger(ClientCredentialsTokenProvider::class.java)
+public object GammelClientCredentialsTokenProvider : TokenProvider {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
     private val client = RestClient.withDefaultResponseHandler(
         config = ClientConfig(),

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/OnBehalfOfTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/azurecc/OnBehalfOfTokenProvider.kt
@@ -15,7 +15,7 @@ import java.net.URLEncoder
 import java.time.Duration
 import kotlin.text.Charsets.UTF_8
 
-@Deprecated("Bruk AzureOBOTokenProvider eller ClientCredentialsTokenProvider")
+@Deprecated("Bruk AzureOBOTokenProvider")
 public object OnBehalfOfTokenProvider : TokenProvider by
 /* Unit-tester feiler i behandlingsflyt. Regner med at endringen må gjøres i behandlingsflyt. Har
  * ikke tid til å undersøke nå. */

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/OnBehalfOfTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/OnBehalfOfTokenProvider.kt
@@ -1,9 +1,8 @@
 package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx
 
-import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.komponenter.config.requiredConfigForKey
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasTokenProvider
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasOBOTokenProvider
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
 import java.net.URI
 
@@ -11,7 +10,7 @@ import java.net.URI
 public class OnBehalfOfTokenProvider(
     texasUri: URI = URI(requiredConfigForKey("nais.token.exchange.endpoint")),
     identityProvider: String = "tokenx",
-) : TokenProvider by TexasTokenProvider(
+) : TokenProvider by TexasOBOTokenProvider(
     texasUri = texasUri,
     identityProvider = identityProvider,
     prometheus = SimpleMeterRegistry(),

--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/TokenxOBOTokenProvider.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/tokenx/TokenxOBOTokenProvider.kt
@@ -3,14 +3,14 @@ package no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.komponenter.config.requiredConfigForKey
-import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasTokenProvider
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TexasOBOTokenProvider
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.TokenProvider
 import java.net.URI
 
 public class TokenxOBOTokenProvider(
     texasUri: URI = URI(requiredConfigForKey("nais.token.exchange.endpoint")),
     prometheus: MeterRegistry = SimpleMeterRegistry(),
-) : TokenProvider by TexasTokenProvider(
+) : TokenProvider by TexasOBOTokenProvider(
     texasUri = texasUri,
     identityProvider = "tokenx",
     prometheus = prometheus,


### PR DESCRIPTION
Felles Texas-oppsett hadde kun støtte for OBO. 
Legger til støtte for M2M (client credentials)