### PR TITLE
AAP-1919 Ktor authentication med texas

### DIFF
--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/OidcTokenResponse.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/tokenprovider/OidcTokenResponse.kt
@@ -12,7 +12,6 @@ internal class OidcTokenResponse(
     @param:JsonProperty("expires_in") val expires_in: Int
 ) {
     override fun toString(): String {
-        return "OidcTokenResponse{" + "token_type='" + token_type + ", scope='" + (scope
-            ?: "") + ", expires_in=" + expires_in + '}'
+        return "OidcTokenResponse(token_type='$token_type', scope='$scope', expires_in='$expires_in')"
     }
 }

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/Authentication.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/Authentication.kt
@@ -9,6 +9,8 @@ import io.ktor.server.auth.jwt.*
 import io.ktor.server.response.*
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureConfig
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx.TokenxConfig
+import no.nav.aap.komponenter.server.auth.IdentityProvider
+import no.nav.aap.komponenter.server.auth.TexasAuthenticationProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -61,5 +63,15 @@ internal fun Application.authentication(azureConfig: AzureConfig?, tokenxConfig:
                 }
             }
         }
+    }
+}
+
+/**
+ * Installerer Authentication med TexasAuthenticationProvider for validering av token.
+ * [Texas](https://docs.nais.io/auth/explanations/#texas)
+ **/
+internal fun Application.authentication(name: IdentityProvider) {
+    install(Authentication) {
+        register(TexasAuthenticationProvider.Config(name).build())
     }
 }

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/Authentication.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/Authentication.kt
@@ -70,8 +70,8 @@ internal fun Application.authentication(azureConfig: AzureConfig?, tokenxConfig:
  * Installerer Authentication med TexasAuthenticationProvider for validering av token.
  * [Texas](https://docs.nais.io/auth/explanations/#texas)
  **/
-internal fun Application.authentication(name: IdentityProvider) {
+internal fun Application.authentication(identityProvider: IdentityProvider) {
     install(Authentication) {
-        register(TexasAuthenticationProvider.Config(name).build())
+        register(TexasAuthenticationProvider.Config(identityProvider).build())
     }
 }

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
@@ -79,21 +79,26 @@ internal class TexasAuthenticationProvider(
                     URI(introspectUrl),
                     postRequest
                 )
-                requireNotNull(response)
+                requireNotNull(response) {
+                    "unauthenticated: fikk tom respons fra introspect"
+                }
             } catch (e: Exception) {
                 logger.error("unauthenticated: introspect request failed: ${e.message}")
                 context.loginChallenge(AuthenticationFailedCause.Error(e.message ?: "introspect request failed"))
                 return
             }
 
-        if (!introspectResponse.active) {
+        if (introspectResponse.active) {
+            /*
+            * TODO:
+            *  Erstatte med egendefinert Principal. Bruker JWT inntil alt er over på Texas.
+            *  Ny principal må også støtte ulikt innhold avhengig av om det er OBO eller M2M.
+            */
+            context.principal(JWTPrincipal(JWT.decode(token)))
+        } else {
             logger.warn("unauthenticated: ${introspectResponse.error}")
             context.loginChallenge(AuthenticationFailedCause.InvalidCredentials)
-            return
         }
-
-        // TODO: Erstatte med egendefinert Principal. Bruker JWT inntil alt er over på Texas.
-        context.principal(JWTPrincipal(JWT.decode(token)))
     }
 
     private data class IntrospectRequest(
@@ -117,5 +122,5 @@ internal class TexasAuthenticationProvider(
 
 public enum class IdentityProvider(public val value: String) {
     ENTRA_ID("entra_id"), // Tidligere AzureAD
-    // TODO: Støtte TokenX i [NaisTokenAuthenticationProvider.kt]
+    TOKENX("tokenx"),
 }

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
@@ -1,0 +1,124 @@
+package no.nav.aap.komponenter.server.auth
+
+import com.auth0.jwt.JWT
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.ktor.http.*
+import io.ktor.http.auth.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
+import io.ktor.server.response.*
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.Header
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.post
+import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.NoTokenTokenProvider
+import org.slf4j.LoggerFactory
+import java.net.URI
+
+/**
+ * Ktor [AuthenticationProvider] that validates Bearer tokens using
+ * [Texas (Token Exchange as a Service)](https://docs.nais.io/auth/explanations/#texas) –
+ * a sidecar provided by the NAIS platform.
+ *
+ * Instead of performing JWT validation locally, this provider delegates token introspection to
+ * the Texas sidecar via its introspection endpoint (`nais.token.introspection.endpoint`).
+ * Texas communicates with the configured identity provider (e.g. Entra ID) and returns whether
+ * the token is active and carries valid claims.
+ *
+ * On a successful introspection the call is authenticated and a [JWTPrincipal] is attached.
+ * If the token is missing, inactive, or the introspection call fails, the request is rejected
+ * with HTTP 401 Unauthorized.
+ *
+ * @see IdentityProvider
+ **/
+internal class TexasAuthenticationProvider(
+    config: Config
+) : AuthenticationProvider(config) {
+    private val logger = LoggerFactory.getLogger(TexasAuthenticationProvider::class.java)
+
+    private val introspectUrl = requireNotNull(System.getProperty("nais.token.introspection.endpoint"))
+    private val client = config.client
+    private val identityProvider = config.identityProvider
+
+    internal class Config(
+        val identityProvider: IdentityProvider
+    ) : AuthenticationProvider.Config(identityProvider.value) {
+        val client = RestClient.withDefaultResponseHandler(
+            config = ClientConfig(),
+            tokenProvider = NoTokenTokenProvider(),
+        )
+
+        internal fun build() = TexasAuthenticationProvider(this)
+    }
+
+    override suspend fun onAuthenticate(context: AuthenticationContext) {
+        val token = (context.call.request.parseAuthorizationHeader() as? HttpAuthHeader.Single)
+            ?.takeIf { header -> header.authScheme.equals(AuthScheme.Bearer, ignoreCase = true) }
+            ?.blob
+
+        if (token == null) {
+            logger.warn("unauthenticated: no Bearer token found in Authorization header")
+            context.loginChallenge(AuthenticationFailedCause.NoCredentials)
+            return
+        }
+
+        val introspectResponse =
+            try {
+                val postRequest = PostRequest(
+                    body = IntrospectRequest(
+                        token = token,
+                        identityProvider = identityProvider.value
+                    ),
+                    additionalHeaders = listOf(
+                        Header("Content-Type", "application/json")
+                    )
+                )
+
+                val response = client.post<IntrospectRequest, IntrospectResponse>(
+                    URI(introspectUrl),
+                    postRequest
+                )
+                requireNotNull(response)
+            } catch (e: Exception) {
+                logger.error("unauthenticated: introspect request failed: ${e.message}")
+                context.loginChallenge(AuthenticationFailedCause.Error(e.message ?: "introspect request failed"))
+                return
+            }
+
+        if (!introspectResponse.active) {
+            logger.warn("unauthenticated: ${introspectResponse.error}")
+            context.loginChallenge(AuthenticationFailedCause.InvalidCredentials)
+            return
+        }
+
+        // TODO: Erstatte med egendefinert Principal. Bruker JWT inntil alt er over på Texas.
+        context.principal(JWTPrincipal(JWT.decode(token)))
+    }
+
+    private data class IntrospectRequest(
+        val token: String,
+        @param:JsonProperty("identity_provider")
+        val identityProvider: String
+    )
+
+    private data class IntrospectResponse(
+        val active: Boolean,
+        val error: String? = null,
+        val azp: String? = null,
+        val idtyp: String? = null,
+        val NAVident: String? = null
+    )
+
+    private fun AuthenticationContext.loginChallenge(cause: AuthenticationFailedCause) {
+        challenge("Texas", cause) { authenticationProcedureChallenge, call ->
+            call.respond(HttpStatusCode.Unauthorized, "")
+            authenticationProcedureChallenge.complete()
+        }
+    }
+}
+
+public enum class IdentityProvider(public val value: String) {
+    ENTRA_ID("entra_id"), // Tidligere AzureAD
+    // TODO: Støtte TokenX i [NaisTokenAuthenticationProvider.kt]
+}

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
@@ -83,7 +83,7 @@ internal class TexasAuthenticationProvider(
                     "unauthenticated: fikk tom respons fra introspect"
                 }
             } catch (e: Exception) {
-                logger.error("unauthenticated: introspect request failed: ${e.message}")
+                logger.error("unauthenticated: introspect request failed", e)
                 context.loginChallenge(AuthenticationFailedCause.Error(e.message ?: "introspect request failed"))
                 return
             }

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/auth/TexasAuthenticationProvider.kt
@@ -105,9 +105,6 @@ internal class TexasAuthenticationProvider(
     private data class IntrospectResponse(
         val active: Boolean,
         val error: String? = null,
-        val azp: String? = null,
-        val idtyp: String? = null,
-        val NAVident: String? = null
     )
 
     private fun AuthenticationContext.loginChallenge(cause: AuthenticationFailedCause) {

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/commonKtorModule.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/commonKtorModule.kt
@@ -39,7 +39,9 @@ public fun Application.commonKtorModule(
     identityProvider: IdentityProvider
 ): CommonResponse = commonKtorModule(
     prometheus = prometheus,
+    azureConfig = null,
     infoModel = infoModel,
+    tokenxConfig = null,
     identityProvider = identityProvider
 )
 

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/commonKtorModule.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/commonKtorModule.kt
@@ -84,7 +84,7 @@ private fun Application.commonKtorModule(
     }
 
     if (identityProvider != null) {
-        authentication(IdentityProvider.ENTRA_ID)
+        authentication(identityProvider)
     } else {
         authentication(azureConfig, tokenxConfig)
     }

--- a/server/src/main/kotlin/no/nav/aap/komponenter/server/commonKtorModule.kt
+++ b/server/src/main/kotlin/no/nav/aap/komponenter/server/commonKtorModule.kt
@@ -14,9 +14,34 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureConfig
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx.TokenxConfig
 import no.nav.aap.komponenter.json.DefaultJsonMapper
+import no.nav.aap.komponenter.server.auth.IdentityProvider
 import no.nav.aap.komponenter.server.auth.bruker
 import no.nav.aap.komponenter.server.common.MdcKeys
 import java.util.*
+
+@Deprecated("Ta i bruk commonKtorModule med identityProvider (med Texas)")
+public fun Application.commonKtorModule(
+    prometheus: MeterRegistry,
+    azureConfig: AzureConfig? = null,
+    infoModel: InfoModel,
+    tokenxConfig: TokenxConfig? = null,
+): CommonResponse = commonKtorModule(
+    prometheus = prometheus,
+    azureConfig = azureConfig,
+    infoModel = infoModel,
+    tokenxConfig = tokenxConfig,
+    identityProvider = null
+)
+
+public fun Application.commonKtorModule(
+    prometheus: MeterRegistry,
+    infoModel: InfoModel,
+    identityProvider: IdentityProvider
+): CommonResponse = commonKtorModule(
+    prometheus = prometheus,
+    infoModel = infoModel,
+    identityProvider = identityProvider
+)
 
 /**
  * Installs common Ktor plugins:
@@ -26,11 +51,12 @@ import java.util.*
  *  - Sets up JWT authentication against Azure or tokenx.
  *  - Genererer Swagger-dokumentasjon
  */
-public fun Application.commonKtorModule(
+private fun Application.commonKtorModule(
     prometheus: MeterRegistry,
     azureConfig: AzureConfig? = null,
     infoModel: InfoModel,
     tokenxConfig: TokenxConfig? = null,
+    identityProvider: IdentityProvider? = null,
 ): CommonResponse {
     install(MicrometerMetrics) {
         registry = prometheus
@@ -55,7 +81,11 @@ public fun Application.commonKtorModule(
         generate { UUID.randomUUID().toString() }
     }
 
-    authentication(azureConfig, tokenxConfig)
+    if (identityProvider != null) {
+        authentication(IdentityProvider.ENTRA_ID)
+    } else {
+        authentication(azureConfig, tokenxConfig)
+    }
 
     val openApiGen = generateOpenAPI(
         infoModel = infoModel


### PR DESCRIPTION
- Legge til ny Ktor authentication med `TexasAuthenticationProvider` (mangler støtte for TokenX enn så lenge)
- Deprecate gammel `commonKtorModule` som ikke bruker Texas
