### PR TITLE
ktor-openapi-generator: legg til responseDescription()-modul

### DIFF
--- a/ktor-openapi-generator/build.gradle.kts
+++ b/ktor-openapi-generator/build.gradle.kts
@@ -47,4 +47,5 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersjon") // junit testing framework
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersjon") // generated parameters for tests
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersjon") // testing runtime
+    testImplementation("org.assertj:assertj-core:3.27.7")
 }

--- a/ktor-openapi-generator/docs/A-few-examples.md
+++ b/ktor-openapi-generator/docs/A-few-examples.md
@@ -31,7 +31,7 @@ application.apiRouting {
 }
 ```
 
-## Expose the OpenAPI.json and swager-ui
+## Expose the OpenAPI.json and swagger-ui
 
 ```kotlin
 application.routing {
@@ -230,8 +230,8 @@ You would define it like this
 
 const val contentType = "image/png"
 
-@BinaryRequest([contentType]) // can be omitted if you don' t want to use it as request
-@BinaryResponse([contentType]) // can be omitted if you don' t want to use it as response
+@BinaryRequest([contentType]) // can be omitted if you don't want to use it as request
+@BinaryResponse([contentType]) // can be omitted if you don't want to use it as response
 data class RawPng(val stream: InputStream)
 
 // then in your route like usual

--- a/ktor-openapi-generator/docs/Modules.md
+++ b/ktor-openapi-generator/docs/Modules.md
@@ -6,10 +6,10 @@ Modules are a way to extend behavior of the routing during Initialisation and Ru
 1. A Module type can be instantiated, but two equal instances cannot coexist (a set is used on the backend)
 2. Modules can be queried by any other module by its class with `ModuleProvider.ofClass<Class>()`
 3. The global module provider can be accessed through an extension or the OpenAPIGen instance with `OpenAPIGen.globalModuleProvider`
-4. The current module provider on a specific route can be accessed through `OpenAPIRoute.provider` (all provided dsl functions properly scope the registered modules, if you implement custom ones make sur you create child handlers using `route.child().apply { provider.registerModule(YourModule()) }.yourBlockFn()`)
+4. The current module provider on a specific route can be accessed through `OpenAPIRoute.provider` (all provided dsl functions properly scope the registered modules, if you implement custom ones make sure you create child handlers using `route.child().apply { provider.registerModule(YourModule()) }.yourBlockFn()`)
 
 #### Key Interfaces: 
-- OpenAPIModule: All modules must implment this interface, it does not have behavior besides indicating intent
+- OpenAPIModule: All modules must implement this interface, it does not have behavior besides indicating intent
 - DependentModule: Allows to declare module dependencies from inside a module
 - RouteOpenAPIModule: Used to indicate that it is to be used as additional module on one specific route, usually for additional metadata like descriptions, it can only be added explicitly during the final call before the route handle (get post, etc... with the parameters `get<Params, Response>(vararg RouteOpenAPIModule) { ... }`)
 - HandlerModule: Provides a hook during route creation, used internally to generate the OpenAPI definition

--- a/ktor-openapi-generator/docs/README.md
+++ b/ktor-openapi-generator/docs/README.md
@@ -1,0 +1,16 @@
+# ktor-openapi-generator
+
+A Ktor plugin that generates OpenAPI/Swagger documentation from your route definitions.
+
+## Documentation
+
+| Page                                                                                                               | Description                                                                 |
+| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [Home](Home.md)                                                                                                    | Overview                                                                    |
+| [Setup](Setup.md)                                                                                                  | Installation and initial configuration                                      |
+| [Basic Routing](Basic-Routing.md)                                                                                  | Defining routes with parameters and response types                          |
+| [Modules](Modules.md)                                                                                              | The module system — `info()`, `status()`, `responseDescription()`, and more |
+| [Response Description](Response-Description.md)                                                                    | Setting response descriptions, including for `List<T>`                      |
+| [Transformers and Validators](<Transformers-and-Validators-(WIP:-needs-more-standard-transformers-validators).md>) | Input validation annotations                                                |
+| [Extensions](<Extensions-(WIP:-needs-more-extensive-hook-system).md>)                                              | Extending the generator                                                     |
+| [A few examples](A-few-examples.md)                                                                                | Code examples                                                               |

--- a/ktor-openapi-generator/docs/Response-Description.md
+++ b/ktor-openapi-generator/docs/Response-Description.md
@@ -1,0 +1,58 @@
+# Response Description
+
+When a route returns a type annotated with [`@Response`](../src/main/kotlin/com/papsign/ktor/openapigen/annotations/Response.kt),
+its `description` field is automatically used as the response description in the generated OpenAPI specification:
+
+```kotlin
+@Response("A list of items")
+data class Item(val id: String, val name: String)
+
+get<Unit, Item> {
+    respond(Item("1", "Foo"))
+}
+```
+
+## The `responseDescription()` module
+
+When the route's response type is a generic wrapper — most commonly `List<T>` — the `@Response` annotation
+on the element type `T` is **not** picked up automatically, because the OpenAPI generator only inspects
+the top-level type.
+
+Use the `responseDescription()` route module to set the description explicitly in those cases:
+
+```kotlin
+get<Unit, List<Item>>(responseDescription("All items for a person")) {
+    respond(listOf(Item("1", "Foo")))
+}
+```
+
+`responseDescription()` works the same way as [`info()`](Basic-Routing.md) and [`status()`](Status-Codes.md) —
+it is passed as an argument to the route method and applies only to that endpoint.
+
+### Priority
+
+When multiple sources provide a description, the priority is:
+
+1. `responseDescription()` module — highest priority, always wins
+2. `@Response.description` on the response type
+3. Default HTTP status description (e.g. `"OK"`) — fallback
+
+### Example: overriding `@Response.description`
+
+`responseDescription()` can also be used to override the description from `@Response` on a
+per-route basis without changing the annotation:
+
+```kotlin
+@Response("Generic item description")
+data class Item(val id: String, val name: String)
+
+// Uses the @Response description
+get<Unit, Item> {
+    respond(Item("1", "Foo"))
+}
+
+// Overrides it for this specific route
+get<Unit, Item>(responseDescription("The primary item for this context")) {
+    respond(Item("1", "Foo"))
+}
+```

--- a/ktor-openapi-generator/docs/Setup.md
+++ b/ktor-openapi-generator/docs/Setup.md
@@ -27,7 +27,7 @@ install(OpenAPIGen) {
     }
 }
 
-// Content negociation is required
+// Content negotiation is required
 install(ContentNegotiation) {
     jackson()
 }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ResponseHandlerModule.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ResponseHandlerModule.kt
@@ -11,6 +11,7 @@ import com.papsign.ktor.openapigen.model.operation.StatusResponseModel
 import com.papsign.ktor.openapigen.modules.ModuleProvider
 import com.papsign.ktor.openapigen.modules.ofType
 import com.papsign.ktor.openapigen.modules.openapi.OperationModule
+import com.papsign.ktor.openapigen.modules.providers.ResponseDescriptionProvider
 import com.papsign.ktor.openapigen.modules.providers.StatusProvider
 import com.papsign.ktor.openapigen.modules.registerModule
 import io.ktor.http.HttpStatusCode
@@ -22,8 +23,9 @@ class ResponseHandlerModule<T>(val responseType: KType, val responseExample: T? 
     private val log = classLogger()
     override fun configure(apiGen: OpenAPIGen, provider: ModuleProvider<*>, operation: OperationModel) {
         val responseMeta = (responseType.classifier as? KAnnotatedElement)?.findAnnotation<Response>()
-        val statusCode =  provider.ofType<StatusProvider>().lastOrNull()?.getStatusForType(responseType) ?: responseMeta?.statusCode?.let { HttpStatusCode.fromValue(it) }
-        ?: HttpStatusCode.OK
+        val statusCode = provider.ofType<StatusProvider>().lastOrNull()?.getStatusForType(responseType)
+            ?: responseMeta?.statusCode?.let { HttpStatusCode.fromValue(it) }
+            ?: HttpStatusCode.OK
         val status = statusCode.value.toString()
         val map = provider.ofType<ResponseSerializer>().mapNotNull {
             val mediaType = it.getMediaType(responseType, apiGen, provider, responseExample, ContentTypeProvider.Usage.SERIALIZE)
@@ -31,15 +33,17 @@ class ResponseHandlerModule<T>(val responseType: KType, val responseExample: T? 
             provider.registerModule(SelectedSerializer(it))
             mediaType.map { Pair(it.key.toString(), it.value) }
         }.flatten().associate { it }
-        val descstr = responseMeta?.description ?: statusCode.description
+        val descstr = provider.ofType<ResponseDescriptionProvider>().lastOrNull()?.description
+            ?: responseMeta?.description
+            ?: statusCode.description
         operation.responses[status] = operation.responses[status]?.apply {
             map.forEach { (key, value) ->
                 content.putIfAbsent(key, value)?.let { if (value != it) log.warn("ContentType of $responseType response $key already registered, ignoring $value") }
             }
             if (description != statusCode.description) {
-                if (responseMeta?.description != null) log.warn("ContentType description of $responseType response already registered, ignoring")
+                if (descstr != statusCode.description) log.warn("ContentType description of $responseType response already registered, ignoring")
             } else {
-                description = responseMeta?.description ?: statusCode.description
+                description = descstr
             }
         } ?: StatusResponseModel(descstr, content = map.toMutableMap())
     }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/ResponseDescriptionProvider.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/ResponseDescriptionProvider.kt
@@ -1,0 +1,16 @@
+package com.papsign.ktor.openapigen.modules.providers
+
+import com.papsign.ktor.openapigen.modules.OpenAPIModule
+
+/**
+ * Module interface for providing a custom description for the success response of an endpoint.
+ *
+ * Implement this interface and register the module on a route to override the description
+ * that would otherwise be derived from the [@Response][com.papsign.ktor.openapigen.annotations.Response]
+ * annotation or the default HTTP status description.
+ *
+ * @see com.papsign.ktor.openapigen.route.ResponseDescriptionModule
+ */
+interface ResponseDescriptionProvider : OpenAPIModule {
+    val description: String
+}

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/ResponseDescription.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/ResponseDescription.kt
@@ -1,0 +1,38 @@
+package com.papsign.ktor.openapigen.route
+
+import com.papsign.ktor.openapigen.OpenAPIGen
+import com.papsign.ktor.openapigen.model.operation.OperationModel
+import com.papsign.ktor.openapigen.modules.ModuleProvider
+import com.papsign.ktor.openapigen.modules.RouteOpenAPIModule
+import com.papsign.ktor.openapigen.modules.openapi.OperationModule
+import com.papsign.ktor.openapigen.modules.providers.ResponseDescriptionProvider
+
+/**
+ * Sets the description of the success response for this endpoint in the OpenAPI specification.
+ *
+ * Useful when the response type is a generic wrapper such as [List] and the [@Response][com.papsign.ktor.openapigen.annotations.Response]
+ * annotation on the element type is not picked up automatically.
+ *
+ * Takes priority over the description from [@Response][com.papsign.ktor.openapigen.annotations.Response].
+ *
+ * Example:
+ * ```
+ * get<Unit, List<Sak>>(responseDescription("All saker for a person")) { ... }
+ * ```
+ *
+ * @param description the description to show in the OpenAPI specification for the success response
+ */
+fun responseDescription(description: String): ResponseDescriptionModule = ResponseDescriptionModule(description)
+
+/**
+ * Module carrying a [description] for the success response.
+ * Consumed by [com.papsign.ktor.openapigen.modules.handlers.ResponseHandlerModule] via [ResponseDescriptionProvider].
+ */
+data class ResponseDescriptionModule(override val description: String) :
+    ResponseDescriptionProvider,
+    RouteOpenAPIModule,
+    OperationModule {
+    override fun configure(apiGen: OpenAPIGen, provider: ModuleProvider<*>, operation: OperationModel) {
+        // Description is read by ResponseHandlerModule via the ResponseDescriptionProvider interface.
+    }
+}

--- a/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/ResponseAnnotationTest.kt
+++ b/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/ResponseAnnotationTest.kt
@@ -1,0 +1,101 @@
+package com.papsign.ktor.openapigen
+
+import TestServer.setupBaseTestServer
+import com.papsign.ktor.openapigen.annotations.Response
+import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.get
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.responseDescription
+import com.papsign.ktor.openapigen.route.route
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class ResponseAnnotationTest {
+
+    @Response(description = "Ressursen ble funnet", statusCode = 200)
+    data class ResponseMed200(val verdi: String)
+
+    @Response(description = "Ressursen ble opprettet", statusCode = 201)
+    data class ResponseMed201(val verdi: String)
+
+    @Test
+    fun `@Response description vises i generert OpenAPI JSON`() = testApplication {
+        application {
+            setupBaseTestServer()
+            apiRouting {
+                route("test-response") {
+                    get<Unit, ResponseMed200> {
+                        respond(ResponseMed200("ok"))
+                    }
+                }
+            }
+        }
+        client.get("http://localhost/openapi.json").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertThat(bodyAsText()).contains(""""description" : "Ressursen ble funnet"""")
+        }
+    }
+
+    @Test
+    fun `@Response statusCode vises i generert OpenAPI JSON`() = testApplication {
+        application {
+            setupBaseTestServer()
+            apiRouting {
+                route("test-response-201") {
+                    get<Unit, ResponseMed201> {
+                        respond(ResponseMed201("opprettet"))
+                    }
+                }
+            }
+        }
+        client.get("http://localhost/openapi.json").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertThat(bodyAsText())
+                .contains(""""201"""")
+                .contains(""""description" : "Ressursen ble opprettet"""")
+        }
+    }
+
+    @Test
+    fun `responseDescription vises i generert OpenAPI JSON for List av T`() = testApplication {
+        application {
+            setupBaseTestServer()
+            apiRouting {
+                route("test-list-response") {
+                    get<Unit, List<ResponseMed200>>(responseDescription("Liste av ressurser")) {
+                        respond(listOf(ResponseMed200("ok")))
+                    }
+                }
+            }
+        }
+        client.get("http://localhost/openapi.json").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertThat(bodyAsText()).contains(""""description" : "Liste av ressurser"""")
+        }
+    }
+
+    @Test
+    fun `responseDescription overstyrer @Response description`() = testApplication {
+        application {
+            setupBaseTestServer()
+            apiRouting {
+                route("test-override") {
+                    get<Unit, ResponseMed200>(responseDescription("Overstyrte beskrivelse")) {
+                        respond(ResponseMed200("ok"))
+                    }
+                }
+            }
+        }
+        client.get("http://localhost/openapi.json").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertThat(bodyAsText())
+                .contains(""""description" : "Overstyrte beskrivelse"""")
+                .doesNotContain(""""description" : "Ressursen ble funnet"""")
+        }
+    }
+}


### PR DESCRIPTION
## Hva

Legger til en ny `responseDescription()`-modul for `ktor-openapi-generator` som lar deg sette beskrivelsen på svartypen i OpenAPI-spesifikasjonen per rute – på samme måte som de eksisterende `info()` og `status()`-modulene.

## Motivasjon

Når en rute returnerer `List<T>` plukker ikke `ResponseHandlerModule` opp `@Response`-annotasjonen på `T`, fordi den kun sjekker toppnivåtypen. Med denne modulen kan man sette beskrivelsen eksplisitt:

```kotlin
get<Unit, List<SakStatus>>(responseDescription("Saker for en person")) { ... }
```

## Endringer

- **`ResponseDescriptionProvider`** – nytt interface (speil av `StatusProvider`)
- **`ResponseDescriptionModule`** / **`responseDescription()`** – modul og hjelpefunksjon (speil av `EndpointInfo` / `info()`)
- **`ResponseHandlerModule`** – bruker nå `ResponseDescriptionProvider` med høyest prioritet for beskrivelse, deretter `@Response.description`, deretter HTTP-standard

Prioritetsrekkefølge: `responseDescription()` > `@Response.description` > HTTP-standard.