### PR TITLE
Fiks kompileringsadvarsler i ktor-openapi-generator

### DIFF
--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExampleProcessor.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExampleProcessor.kt
@@ -6,6 +6,7 @@ import kotlin.reflect.KType
 
 object StringExampleProcessor: SchemaProcessor<StringExample> {
     override fun process(model: SchemaModel<*>, type: KType, annotation: StringExample): SchemaModel<*> {
+        @Suppress("UNCHECKED_CAST")
         (model as SchemaModel<String?>).apply {
             if (annotation.examples.size > 1) {
                 examples = examples?.plus(annotation.examples) ?: annotation.examples.asList()

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/model/DataModel.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/model/DataModel.kt
@@ -9,6 +9,7 @@ interface DataModel {
 
     fun serialize(): Map<String, Any?> {
         return this::class.memberProperties.associateBy { it.name }.mapValues { (_, prop) ->
+            @Suppress("UNCHECKED_CAST")
             convertToValue((prop as KProperty1<DataModel, *>).get(this))
         }.cleanEmptyValues()
     }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecuritySchemeModel.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecuritySchemeModel.kt
@@ -20,6 +20,7 @@ data class SecuritySchemeModel<TScope> constructor(
 
     override fun serialize(): Map<String, Any?> {
         return this::class.memberProperties.associateBy { it.name }.mapValues<String, KProperty1<out SecuritySchemeModel<TScope>, Any?>, Any?> { (_, prop) ->
+            @Suppress("UNCHECKED_CAST")
             convertToValue((prop as KProperty1<DataModel, *>).get(this))
         }.filter { it.key != "referenceName" }.cleanEmptyValues()
     }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/modules/ModuleProvider.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/modules/ModuleProvider.kt
@@ -11,6 +11,7 @@ interface ModuleProvider<THIS: ModuleProvider<THIS>> {
 }
 
 inline fun <reified T: OpenAPIModule> ModuleProvider<*>.ofType(): Collection<T> {
+    @Suppress("UNCHECKED_CAST")
     return ofType(getKType<T>()) as Collection<T>
 }
 

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/Functions.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/Functions.kt
@@ -11,7 +11,6 @@ import com.papsign.ktor.openapigen.route.modules.PathProviderModule
 import io.ktor.http.HttpMethod
 import io.ktor.server.routing.HttpMethodRouteSelector
 import io.ktor.server.routing.createRouteFromPath
-import io.ktor.utils.io.KtorDsl
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.KVariance
@@ -29,7 +28,6 @@ fun <T : OpenAPIRoute<T>> T.route(path: String): T {
 /**
  * Creates a new route matching the specified [path]
  */
-@KtorDsl
 inline fun <TRoute : OpenAPIRoute<TRoute>> TRoute.route(path: String, crossinline fn: TRoute.() -> Unit) {
     route(path).fn()
 }
@@ -43,7 +41,6 @@ fun <TRoute : OpenAPIRoute<TRoute>> TRoute.method(method: HttpMethod): TRoute {
 /**
  * Creates a new route matching the specified [method]
  */
-@KtorDsl
 inline fun <TRoute : OpenAPIRoute<TRoute>> TRoute.method(method: HttpMethod, crossinline fn: TRoute.() -> Unit) {
     method(method).fn()
 }
@@ -59,7 +56,6 @@ fun <TRoute : OpenAPIRoute<TRoute>> TRoute.provider(vararg content: ContentTypeP
 /**
  * Creates a new route matching the specified [content]
  */
-@KtorDsl
 inline fun <TRoute : OpenAPIRoute<TRoute>> TRoute.provider(vararg content: ContentTypeProvider, crossinline fn: TRoute.() -> Unit) {
     provider(*content).fn()
 }
@@ -107,7 +103,6 @@ fun <TRoute : OpenAPIRoute<TRoute>> TRoute.tag(tag: APITag): TRoute {
  * @param tag the tag to apply
  * @param fn the block where the sub routes are defined
  */
-@KtorDsl
 inline fun <TRoute : OpenAPIRoute<TRoute>> TRoute.tag(tag: APITag, crossinline fn: TRoute.() -> Unit) {
     tag(tag).fn()
 }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/RouteConfig.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/RouteConfig.kt
@@ -7,13 +7,11 @@ import io.ktor.server.application.plugin
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.application
 import io.ktor.server.routing.routing
-import io.ktor.utils.io.KtorDsl
 
 /**
  * Wrapper for [io.ktor.server.routing.routing] to create the endpoints while configuring OpenAPI
  * documentation at the same time.
  */
-@KtorDsl
 fun Application.apiRouting(config: NormalOpenAPIRoute.() -> Unit) {
     routing {
         NormalOpenAPIRoute(
@@ -29,7 +27,6 @@ fun Application.apiRouting(config: NormalOpenAPIRoute.() -> Unit) {
  *
  * @param config
  */
-@KtorDsl
 fun Route.apiRouting(config: NormalOpenAPIRoute.() -> Unit) {
     NormalOpenAPIRoute(
         this,

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/Throws.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/Throws.kt
@@ -72,6 +72,7 @@ fun makeExceptionHandler(info: Array<out APIException<*, *>>): suspend PipelineC
     }
     return { t: Throwable ->
         val handler: APIException<*, *> = findHandlerByType(t::class) ?: throw t
+        @Suppress("UNCHECKED_CAST")
         val gen = handler.contentGen as ((Throwable) -> Any?)?
         val ex = handler.example
         when {

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/Functions.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/Functions.kt
@@ -5,18 +5,15 @@ import com.papsign.ktor.openapigen.route.method
 import com.papsign.ktor.openapigen.route.preHandle
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineAuthContext
 import io.ktor.http.HttpMethod
-import io.ktor.utils.io.KtorDsl
 import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.typeOf
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.get(
     vararg modules: RouteOpenAPIModule,
     example: TResponse? = null,
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams) -> Unit
 ) = route(HttpMethod.Get, modules, example, body)
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.post(
     vararg modules: RouteOpenAPIModule,
     exampleResponse: TResponse? = null,
@@ -24,7 +21,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams, TRequest) -> Unit
 ) = route(HttpMethod.Post, modules, exampleResponse, exampleRequest, body)
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.put(
     vararg modules: RouteOpenAPIModule,
     exampleResponse: TResponse? = null,
@@ -32,7 +28,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams, TRequest) -> Unit
 ) = route(HttpMethod.Put, modules, exampleResponse, exampleRequest, body)
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.patch(
     vararg modules: RouteOpenAPIModule,
     exampleResponse: TResponse? = null,
@@ -40,21 +35,18 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams, TRequest) -> Unit
 ) = route(HttpMethod.Patch, modules, exampleResponse, exampleRequest, body)
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.delete(
     vararg modules: RouteOpenAPIModule,
     example: TResponse? = null,
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams) -> Unit
 ) = route(HttpMethod.Delete, modules, example, body)
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.head(
     vararg modules: RouteOpenAPIModule,
     example: TResponse? = null,
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams) -> Unit
 ) = route(HttpMethod.Head, modules, example, body)
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.route(
     method: HttpMethod,
     modules: Array<out RouteOpenAPIModule>,
@@ -66,7 +58,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
         .handle(exampleResponse, exampleRequest, body)
 }
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.route(
     method: HttpMethod,
     modules: Array<out RouteOpenAPIModule>,
@@ -77,7 +68,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, TAuth> OpenAPIAuthen
         .handle(exampleResponse, body)
 }
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.handle(
     exampleResponse: TResponse? = null,
     exampleRequest: TRequest? = null,
@@ -91,7 +81,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     }
 }
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, TAuth> OpenAPIAuthenticatedRoute<TAuth>.handle(
     exampleResponse: TResponse? = null,
     noinline body: suspend OpenAPIPipelineAuthContext<TAuth, TResponse>.(TParams) -> Unit

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/Functions.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/Functions.kt
@@ -5,7 +5,6 @@ import com.papsign.ktor.openapigen.route.method
 import com.papsign.ktor.openapigen.route.preHandle
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineResponseContext
 import io.ktor.http.HttpMethod
-import io.ktor.utils.io.KtorDsl
 import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.typeOf
 
@@ -19,7 +18,6 @@ import kotlin.reflect.typeOf
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.get(
     vararg modules: RouteOpenAPIModule,
     example: TResponse? = null,
@@ -38,7 +36,6 @@ inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.g
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any> NormalOpenAPIRoute.post(
     vararg modules: RouteOpenAPIModule,
     exampleResponse: TResponse? = null,
@@ -58,7 +55,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any> NormalOpenAPIRoute.put(
     vararg modules: RouteOpenAPIModule,
     exampleResponse: TResponse? = null,
@@ -78,7 +74,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any> NormalOpenAPIRoute.patch(
     vararg modules: RouteOpenAPIModule,
     exampleResponse: TResponse? = null,
@@ -96,7 +91,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.delete(
     vararg modules: RouteOpenAPIModule,
     example: TResponse? = null,
@@ -113,7 +107,6 @@ inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.d
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.head(
     vararg modules: RouteOpenAPIModule,
     example: TResponse? = null,
@@ -133,7 +126,6 @@ inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.h
  * @param body a block that received the request parameters builds the response
  * @return the new created route
  */
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any> NormalOpenAPIRoute.route(
     method: HttpMethod,
     modules: Array<out RouteOpenAPIModule>,
@@ -145,7 +137,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
         .handle(exampleResponse, exampleRequest, body)
 }
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.route(
     method: HttpMethod,
     modules: Array<out RouteOpenAPIModule>,
@@ -156,7 +147,6 @@ inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.r
         .handle(exampleResponse, body)
 }
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : Any> NormalOpenAPIRoute.handle(
     exampleResponse: TResponse? = null,
     exampleRequest: TRequest? = null,
@@ -170,7 +160,6 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     }
 }
 
-@KtorDsl
 inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.handle(
     exampleResponse: TResponse? = null,
     noinline body: suspend OpenAPIPipelineResponseContext<TResponse>.(TParams) -> Unit

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/schema/builder/provider/DefaultEnumObjectSchemaProvider.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/schema/builder/provider/DefaultEnumObjectSchemaProvider.kt
@@ -17,7 +17,7 @@ import com.papsign.ktor.openapigen.schema.builder.FinalSchemaBuilder
 import com.papsign.ktor.openapigen.schema.builder.SchemaBuilder
 import com.papsign.ktor.openapigen.schema.namer.DefaultSchemaNamer
 import com.papsign.ktor.openapigen.schema.namer.SchemaNamer
-import io.ktor.util.reflect.platformType
+import kotlin.reflect.jvm.javaType
 import kotlin.collections.set
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
@@ -96,7 +96,7 @@ object DefaultEnumObjectSchemaProvider : SchemaBuilderProviderModule, OpenAPIGen
 
         override fun checkType(type: KType) {
             if (type.isSubtypeOf(getKType<Enum<*>?>())) {
-                val jsonFormat = (type.platformType as Class<*>).getAnnotation(JsonFormat::class.java)
+                val jsonFormat = (type.javaType as Class<*>).getAnnotation(JsonFormat::class.java)
                 if (jsonFormat != null && jsonFormat.shape == JsonFormat.Shape.OBJECT) {
                     return
                 }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/schema/builder/provider/FinalSchemaBuilderProvider.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/schema/builder/provider/FinalSchemaBuilderProvider.kt
@@ -12,7 +12,7 @@ import com.papsign.ktor.openapigen.schema.builder.FinalSchemaBuilder
 import com.papsign.ktor.openapigen.schema.builder.SchemaBuilder
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessor
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
-import io.ktor.util.reflect.platformType
+import kotlin.reflect.jvm.javaType
 import java.util.Optional
 import java.util.TreeMap
 import kotlin.reflect.KType
@@ -92,7 +92,7 @@ object FinalSchemaBuilderProvider : FinalSchemaBuilderProviderModule, OpenAPIGen
 
         private fun extractedType(type: KType): KType {
             if (type.isSubtypeOf(getKType<Enum<*>?>())) {
-                val jsonFormat = (type.platformType as Class<*>).getAnnotation(JsonFormat::class.java)
+                val jsonFormat = (type.javaType as Class<*>).getAnnotation(JsonFormat::class.java)
                 if (jsonFormat != null && jsonFormat.shape == JsonFormat.Shape.OBJECT) {
                     return getKType<ComplexEnum>()
                 }

--- a/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/validation/ValidationHandler.kt
+++ b/ktor-openapi-generator/src/main/kotlin/com/papsign/ktor/openapigen/validation/ValidationHandler.kt
@@ -29,7 +29,10 @@ class ValidationHandler private constructor(
         val type = annotatedType.type
         val validators = annotations.mapNotNull { annot ->
             annot.annotationClass.findAnnotation<ValidatorAnnotation>()
-                ?.let { (it.getHandlerInstance() as ValidatorBuilder<Annotation>).build(type, annot) }
+                ?.let {
+                    @Suppress("UNCHECKED_CAST")
+                    (it.getHandlerInstance() as ValidatorBuilder<Annotation>).build(type, annot)
+                }
         }
         val shouldTransform = validators.isNotEmpty()
         val transform: (Any?) -> Any? = { source: Any? ->
@@ -302,6 +305,7 @@ class ValidationHandler private constructor(
     }
 
     fun <T> handle(t: T): T {
+        @Suppress("UNCHECKED_CAST")
         return if (t != null) transformFun?.invoke(t) as T ?: t else t
     }
 

--- a/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/EnumNonStrictTestServer.kt
+++ b/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/EnumNonStrictTestServer.kt
@@ -23,10 +23,10 @@ enum class NonStrictTestEnum {
 }
 
 @Path("/")
-data class NullableNonStrictEnumParams(@QueryParam("") val type: NonStrictTestEnum? = null)
+data class NullableNonStrictEnumParams(@param:QueryParam("") val type: NonStrictTestEnum? = null)
 
 @Path("/")
-data class NonNullableNonStrictEnumParams(@QueryParam("") val type: NonStrictTestEnum)
+data class NonNullableNonStrictEnumParams(@param:QueryParam("") val type: NonStrictTestEnum)
 
 class NonStrictEnumTestServer {
 

--- a/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProviderTest.kt
+++ b/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProviderTest.kt
@@ -32,6 +32,7 @@ class MultipartFormDataContentProviderTest {
                              val bln: Boolean?) {
         fun toParts(): List<PartData> {
             return this::class.declaredMemberProperties.mapNotNull {
+                @Suppress("UNCHECKED_CAST")
                 val prop = it as KProperty1<SimpleRequest, Any?>
                 val res = prop.get(this) ?: return@mapNotNull null
                 PartData.FormItem(

--- a/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericRoutesTest.kt
+++ b/ktor-openapi-generator/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericRoutesTest.kt
@@ -172,7 +172,7 @@ class GenericRoutesTest {
         fun removeNode(nodeId: Long)
     }
 
-    data class PathId(@PathParam("Id") val id: Long)
+    data class PathId(@param:PathParam("Id") val id: Long)
 
     private inline fun <reified TNodeNew : TreeNodeNew, reified TNode : TreeNodeBase> NormalOpenAPIRoute.treeNodeRoute(
         service: TreeNodeService<TNodeNew, TNode>


### PR DESCRIPTION
Fikser kompileringsadvarsler i ktor-openapi-generator-pakken:

- Fjern `@KtorDsl` fra top-level-funksjoner (har ingen effekt på funksjoner, kun på typer)
- Legg til `@Suppress("UNCHECKED_CAST")` der nødvendig
- Erstatt deprecated `platformType` med `javaType`
- Bruk eksplisitt `@param:` annotasjonsmål i tester

Deprecation-advarsler som ikke kan fikses ennå er beholdt som de er (`Route.intercept`, `isAccessible`, `setSerializationInclusion`).