### PR TITLE
Logger ikke error ved exceptions i retry som ikke er retryExceptions

### DIFF
--- a/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/RestClient.kt
+++ b/httpklient/src/main/kotlin/no/nav/aap/komponenter/httpklient/httpclient/RestClient.kt
@@ -110,11 +110,15 @@ public class RestClient<K>(
         try {
             return function()
         } catch (ex: Exception) {
-            if (retryExceptions.contains(ex::class) && retries - 1 > 0) {
-                log.info("Feilet kall mot $uri, retryer : {}", ex.message)
-                return retry(retries - 1, uri, function)
+            if (retryExceptions.contains(ex::class)) {
+                if (retries - 1 > 0) {
+                    log.info("Feilet kall mot $uri, retryer : {}", ex.message)
+                    return retry(retries - 1, uri, function)
+                } else {
+                    log.error("Rekjører ikke flere ganger mot $uri", ex)
+                    throw ex
+                }
             } else {
-                log.error("Rekjører ikke flere ganger mot $uri", ex)
                 throw ex
             }
         }


### PR DESCRIPTION
Ved feks `ManglerTilgangException` som kastes ved bruk av `retry` så vil det nå logges en error fra `RestClient` selv om dette er et helt forventet utfall og blir håndtert i klienten. 

Blir riktigere å skille ut det som betraktes som retryExceptions i en egen branch hvor det evnt logges feil, mens andre exceptions bare kastes videre.