### PR TITLE
Legg på span rundt transaksjoner

### DIFF
--- a/dbconnect/build.gradle.kts
+++ b/dbconnect/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(libs.slfj)
 
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.22.0")
     implementation(kotlin("reflect"))
     testImplementation(project(":dbtest"))
     testImplementation("org.postgresql:postgresql:42.7.11")

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DBConnect.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DBConnect.kt
@@ -2,17 +2,21 @@ package no.nav.aap.komponenter.dbconnect
 
 import javax.sql.DataSource
 
+
 /**
  * Start en transaksjon.
  *
  * @param readOnly Om transaksjonen skal være i read-only modus. Defaulter til false.
  */
 public fun <T> DataSource.transaction(readOnly: Boolean = false, block: (DBConnection) -> T): T {
-    return this.connection.use { connection ->
-        if (readOnly) {
-            connection.isReadOnly = true // Setter transaction i read-only
+    return span("transaction", listOf("readOnly" to readOnly.toString())) {
+        this.connection.use { connection ->
+            if (readOnly) {
+                connection.isReadOnly = true // Setter transaction i read-only
+            }
+            val dbTransaction = DBTransaction(connection, readOnly)
+            dbTransaction.transaction(block)
         }
-        val dbTransaction = DBTransaction(connection, readOnly)
-        dbTransaction.transaction(block)
     }
 }
+

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DBTransaction.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DBTransaction.kt
@@ -13,7 +13,10 @@ internal class DBTransaction(connection: Connection, private val readOnly: Boole
     internal fun <T> transaction(block: (DBConnection) -> T): T {
         try {
             dbConnection.autoCommitOff()
-            val result = block(dbConnection)
+
+            val result = span("transaction-body") {
+                block(dbConnection)
+            }
             // Commit må kalles på i readOnly og read/write for å frigjøre eventuelle låser
             dbConnection.commit()
             return result

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Trace.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Trace.kt
@@ -1,0 +1,32 @@
+package no.nav.aap.komponenter.dbconnect
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+
+internal val tracer = GlobalOpenTelemetry.getTracer("transaction")
+
+internal inline fun <T> span(
+    name: String,
+    attributes: List<Pair<String, String>> = emptyList(),
+    body: () -> T,
+): T {
+    val outerSpan = tracer.spanBuilder(name)
+        .setSpanKind(SpanKind.INTERNAL)
+        .apply {
+            for ((key, value) in attributes) {
+                setAttribute(key, value)
+            }
+        }
+        .startSpan()
+    try {
+        return body()
+    } catch (e: Throwable) {
+        outerSpan.setStatus(StatusCode.ERROR)
+        outerSpan.setAttribute(AttributeKey.stringKey("error.type"), e.javaClass.getCanonicalName())
+        throw e
+    } finally {
+        outerSpan.end()
+    }
+}


### PR DESCRIPTION
Legger span både utenfor transaksjonen og inni transaksjonen  slik at vi kan skille mellom tiden som brukes på å få connection og commite, og på koden som kjører i transaksjonen.