### PR TITLE
Jobb-tabellen i behandlingsflyt har blitt veldig stor - og tilsvarend…

### DIFF
--- a/motor/src/main/kotlin/no/nav/aap/motor/JobbType.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/JobbType.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.motor
 
+import no.nav.aap.motor.jobbarkiv.ArkiverFerdigstilteJobb
 import no.nav.aap.motor.retry.RekjørFeiledeJobb
 
 public object JobbType {
@@ -7,6 +8,7 @@ public object JobbType {
 
     init {
         jobber[RekjørFeiledeJobb.type] = RekjørFeiledeJobb
+        jobber[ArkiverFerdigstilteJobb.type] = ArkiverFerdigstilteJobb
     }
 
     public fun leggTil(jobb: JobbSpesifikasjon) {

--- a/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobb.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobb.kt
@@ -20,10 +20,10 @@ internal class ArkiverFerdigstilteJobb(private val repository: ArkiverFerdigstil
 
             while (true) {
                 val arkiverteDenneRunden = repository.arkiverFerdigstilteJobber(BATCH_STØRRELSE)
+                antallArkiverteJobber += arkiverteDenneRunden
                 if (arkiverteDenneRunden != BATCH_STØRRELSE) {
                     break
                 }
-                antallArkiverteJobber += arkiverteDenneRunden
             }
 
             log.info("Arkivert {} jobber til jobbarkivet", antallArkiverteJobber)

--- a/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobb.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobb.kt
@@ -1,0 +1,54 @@
+package no.nav.aap.motor.jobbarkiv
+
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.motor.ConnectionJobbSpesifikasjon
+import no.nav.aap.motor.JobbInput
+import no.nav.aap.motor.JobbUtfører
+import no.nav.aap.motor.cron.CronExpression
+import org.slf4j.LoggerFactory
+
+internal const val ARKIVER_FERDIGSTILTE_JOBBER = "jobber.arkiverFerdigstilte"
+internal const val BATCH_STØRRELSE = 50_000
+
+internal class ArkiverFerdigstilteJobb(private val repository: ArkiverFerdigstilteJobberRepository) : JobbUtfører {
+    private val log = LoggerFactory.getLogger(ArkiverFerdigstilteJobb::class.java)
+
+    override fun utfør(input: JobbInput) {
+
+        if (repository.arkivtabellerFinnes()) {
+            var antallArkiverteJobber = 0
+
+            while (true) {
+                val arkiverteDenneRunden = repository.arkiverFerdigstilteJobber(BATCH_STØRRELSE)
+                if (arkiverteDenneRunden != BATCH_STØRRELSE) {
+                    break
+                }
+                antallArkiverteJobber += arkiverteDenneRunden
+            }
+
+            log.info("Arkivert {} jobber til jobbarkivet", antallArkiverteJobber)
+
+        } else {
+            log.info("Finnes ingen arkivtabeller - kan derfor ikke arkivere ferdigstilte jobber")
+        }
+    }
+
+    companion object : ConnectionJobbSpesifikasjon {
+        override fun konstruer(connection: DBConnection): JobbUtfører {
+            return ArkiverFerdigstilteJobb(ArkiverFerdigstilteJobberRepository(connection))
+        }
+
+        override val type = ARKIVER_FERDIGSTILTE_JOBBER
+
+        override val navn = "Arkiver ferdigstilte jobber"
+
+        override val beskrivelse =
+            "Finner ferdigstilte jobber og flytter disse til arkivtabeller dersom det eksisterer."
+
+        /**
+         * Hver dag kl 01:00
+         */
+        override val cron = CronExpression.create("0 0 1 * * *")
+
+    }
+}

--- a/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobb.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobb.kt
@@ -7,7 +7,7 @@ import no.nav.aap.motor.JobbUtfører
 import no.nav.aap.motor.cron.CronExpression
 import org.slf4j.LoggerFactory
 
-internal const val ARKIVER_FERDIGSTILTE_JOBBER = "jobber.arkiverFerdigstilte"
+internal const val ARKIVER_FERDIGSTILTE_JOBB_TYPE = "jobber.arkiverFerdigstilte"
 internal const val BATCH_STØRRELSE = 50_000
 
 internal class ArkiverFerdigstilteJobb(private val repository: ArkiverFerdigstilteJobberRepository) : JobbUtfører {
@@ -38,7 +38,7 @@ internal class ArkiverFerdigstilteJobb(private val repository: ArkiverFerdigstil
             return ArkiverFerdigstilteJobb(ArkiverFerdigstilteJobberRepository(connection))
         }
 
-        override val type = ARKIVER_FERDIGSTILTE_JOBBER
+        override val type = ARKIVER_FERDIGSTILTE_JOBB_TYPE
 
         override val navn = "Arkiver ferdigstilte jobber"
 

--- a/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobberRepository.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobberRepository.kt
@@ -1,0 +1,85 @@
+package no.nav.aap.motor.jobbarkiv
+
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.motor.JobbStatus
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+internal class ArkiverFerdigstilteJobberRepository(private val connection: DBConnection) {
+    private val log = LoggerFactory.getLogger(ArkiverFerdigstilteJobberRepository::class.java)
+
+    internal fun arkiverFerdigstilteJobber(batchStørrelse: Int): Int {
+        if (!arkivtabellerFinnes()) {
+            log.info("Kan ikke gjennomføre arkivering: mangler tabellene jobb_arkiv og/eller jobb_historikk_arkiv")
+            return 0
+        }
+
+        val cutoff = LocalDateTime.now().minusDays(DAGER_FOR_ARKIVERING)
+
+        val query = """
+            WITH kandidater_for_arkivering AS (
+                SELECT id
+                FROM JOBB
+                WHERE status = ?
+                  AND neste_kjoring < ?
+                LIMIT $batchStørrelse
+            ),
+            jobber_arkivert AS (
+                INSERT INTO jobb_arkiv
+                    (id, status, type, sak_id, behandling_id, parameters, payload, neste_kjoring, opprettet_tid)
+                SELECT j.id, j.status, j.type, j.sak_id, j.behandling_id, j.parameters, j.payload, j.neste_kjoring, j.opprettet_tid
+                FROM JOBB j
+                INNER JOIN kandidater_for_arkivering k ON k.id = j.id
+            ),
+            jobb_historikk_arkivert AS (
+                INSERT INTO jobb_historikk_arkiv
+                    (id, jobb_id, status, feilmelding, opprettet_tid)
+                SELECT h.id, h.jobb_id, h.status, h.feilmelding, h.opprettet_tid
+                FROM JOBB_HISTORIKK h
+                INNER JOIN kandidater_for_arkivering k ON k.id = h.jobb_id
+            ),
+            jobb_historikk_slettet AS (
+                DELETE FROM JOBB_HISTORIKK h
+                USING kandidater_for_arkivering k
+                WHERE h.jobb_id = k.id
+            ),
+            jobber_slettet AS (
+                DELETE FROM JOBB j
+                USING kandidater_for_arkivering k
+                WHERE j.id = k.id
+                RETURNING j.id
+            )
+            SELECT count(*) AS antall
+            FROM jobber_slettet
+        """.trimIndent()
+
+        return connection.queryFirst(query) {
+            setParams {
+                setEnumName(1, JobbStatus.FERDIG)
+                setLocalDateTime(2, cutoff)
+            }
+            setRowMapper {
+                it.getInt("antall")
+            }
+        }
+    }
+
+    internal fun arkivtabellerFinnes(): Boolean {
+        val query = """
+            SELECT
+                to_regclass('public.jobb_arkiv') IS NOT NULL AS jobb_arkiv_finnes,
+                to_regclass('public.jobb_historikk_arkiv') IS NOT NULL AS jobb_historikk_arkiv_finnes
+        """.trimIndent()
+
+        return connection.queryFirst(query) {
+            setRowMapper {
+                it.getBoolean("jobb_arkiv_finnes") && it.getBoolean("jobb_historikk_arkiv_finnes")
+            }
+        }
+    }
+
+    private companion object {
+        const val DAGER_FOR_ARKIVERING = 60L
+    }
+
+}

--- a/motor/src/test/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobbRepositoryTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/jobbarkiv/ArkiverFerdigstilteJobbRepositoryTest.kt
@@ -1,0 +1,261 @@
+package no.nav.aap.motor.jobbarkiv
+
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.dbconnect.transaction
+import no.nav.aap.komponenter.dbtest.TestDataSource
+import no.nav.aap.motor.JobbInput
+import no.nav.aap.motor.JobbStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AutoClose
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+internal class ArkiverFerdigstilteJobbRepositoryTest {
+
+    @AutoClose
+    private val dataSource = TestDataSource()
+
+    @Test
+    fun `skal ikke arkivere jobber når arkivtabeller mangler`() {
+        dataSource.transaction { connection ->
+            val gammelFerdigJobbId =
+                opprettJobb(connection, JobbStatus.FERDIG, LocalDateTime.now().minusDays(61), "mangler-arkiv")
+            opprettHistorikk(connection, gammelFerdigJobbId, JobbStatus.FERDIG)
+
+            ArkiverFerdigstilteJobb(ArkiverFerdigstilteJobberRepository(connection)).utfør(
+                JobbInput(ArkiverFerdigstilteJobb.Companion)
+            )
+
+            assertThat(ArkiverFerdigstilteJobberRepository(connection).arkivtabellerFinnes()).isFalse()
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM JOBB WHERE id = $gammelFerdigJobbId"
+                )
+            ).isEqualTo(1)
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM JOBB_HISTORIKK WHERE jobb_id = $gammelFerdigJobbId"
+                )
+            ).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `skal kun arkivere ferdige jobber eldre enn 60 dager`() {
+        dataSource.transaction { connection ->
+            opprettArkivtabeller(connection)
+            val gammelFerdigJobbId =
+                opprettJobb(connection, JobbStatus.FERDIG, LocalDateTime.now().minusDays(61), "eldre-ferdig")
+            val nyFerdigJobbId =
+                opprettJobb(connection, JobbStatus.FERDIG, LocalDateTime.now().minusDays(10), "nyere-ferdig")
+            val gammelKlarJobbId =
+                opprettJobb(connection, JobbStatus.KLAR, LocalDateTime.now().minusDays(61), "eldre-klar")
+
+            opprettHistorikk(connection, gammelFerdigJobbId, JobbStatus.KLAR)
+            opprettHistorikk(connection, gammelFerdigJobbId, JobbStatus.FERDIG)
+            opprettHistorikk(connection, nyFerdigJobbId, JobbStatus.FERDIG)
+            opprettHistorikk(connection, gammelKlarJobbId, JobbStatus.KLAR)
+
+            val antallArkiverte = ArkiverFerdigstilteJobberRepository(connection).arkiverFerdigstilteJobber(20)
+
+            assertThat(antallArkiverte).isEqualTo(1)
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM JOBB WHERE id = $gammelFerdigJobbId"
+                )
+            ).isZero()
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM JOBB WHERE id = $nyFerdigJobbId"
+                )
+            ).isEqualTo(1)
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM JOBB WHERE id = $gammelKlarJobbId"
+                )
+            ).isEqualTo(1)
+
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM jobb_arkiv WHERE id = $gammelFerdigJobbId"
+                )
+            ).isEqualTo(1)
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM JOBB_HISTORIKK WHERE jobb_id = $gammelFerdigJobbId"
+                )
+            ).isZero()
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM jobb_historikk_arkiv WHERE jobb_id = $gammelFerdigJobbId"
+                )
+            ).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `skal kun prosessere så mange som batchen tillater`() {
+        dataSource.transaction { connection ->
+            opprettArkivtabeller(connection)
+            val cutoff = LocalDateTime.now().minusDays(61)
+
+            connection.execute(
+                """
+                INSERT INTO JOBB (status, type, neste_kjoring)
+                SELECT '${JobbStatus.FERDIG.name}', 'batch-jobb', ?
+                FROM generate_series(1, 170)
+                """.trimIndent()
+            ) {
+                setParams {
+                    setLocalDateTime(1, cutoff)
+                }
+            }
+
+            connection.execute(
+                """
+                INSERT INTO JOBB_HISTORIKK (jobb_id, status, opprettet_tid)
+                SELECT id, '${JobbStatus.FERDIG.name}', CURRENT_TIMESTAMP
+                FROM JOBB
+                WHERE type = 'batch-jobb'
+                """.trimIndent()
+            )
+
+            val repository = ArkiverFerdigstilteJobberRepository(connection)
+            val arkiverteDenneRunden = repository.arkiverFerdigstilteJobber(100)
+
+            assertThat(arkiverteDenneRunden).isEqualTo(100)
+            assertThat(antall(connection, "SELECT count(*) AS antall FROM JOBB WHERE type = 'batch-jobb'")).isEqualTo(70)
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM jobb_arkiv WHERE type = 'batch-jobb'"
+                )
+            ).isEqualTo(100)
+        }
+    }
+
+    @Test
+    fun `skal prosessere flere batcher til tomt`() {
+        dataSource.transaction { connection ->
+            opprettArkivtabeller(connection)
+            val cutoff = LocalDateTime.now().minusDays(61)
+
+            connection.execute(
+                """
+                INSERT INTO JOBB (status, type, neste_kjoring)
+                SELECT '${JobbStatus.FERDIG.name}', 'batch-jobb', ?
+                FROM generate_series(1, 50_001)
+                """.trimIndent()
+            ) {
+                setParams {
+                    setLocalDateTime(1, cutoff)
+                }
+            }
+
+            connection.execute(
+                """
+                INSERT INTO JOBB_HISTORIKK (jobb_id, status, opprettet_tid)
+                SELECT id, '${JobbStatus.FERDIG.name}', CURRENT_TIMESTAMP
+                FROM JOBB
+                WHERE type = 'batch-jobb'
+                """.trimIndent()
+            )
+
+            val arkiverFerdigstilteJobb = ArkiverFerdigstilteJobb(ArkiverFerdigstilteJobberRepository(connection))
+
+            arkiverFerdigstilteJobb.utfør(JobbInput(ArkiverFerdigstilteJobb))
+
+            assertThat(antall(connection, "SELECT count(*) AS antall FROM JOBB WHERE type = 'batch-jobb'")).isZero()
+            assertThat(
+                antall(
+                    connection,
+                    "SELECT count(*) AS antall FROM jobb_arkiv WHERE type = 'batch-jobb'"
+                )
+            ).isEqualTo(50_001)
+        }
+    }
+
+    private fun opprettArkivtabeller(connection: DBConnection) {
+        connection.execute(
+            """
+            CREATE TABLE jobb_arkiv
+            (
+                ID            BIGINT                                 NOT NULL PRIMARY KEY,
+                STATUS        VARCHAR(50)                            NOT NULL,
+                TYPE          VARCHAR(50)                            NOT NULL,
+                SAK_ID        BIGINT NULL,
+                BEHANDLING_ID BIGINT NULL,
+                parameters    text NULL,
+                payload       text NULL,
+                NESTE_KJORING TIMESTAMP(3)                           NOT NULL,
+                OPPRETTET_TID TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL
+            )
+            """.trimIndent()
+        )
+
+        connection.execute(
+            """
+            CREATE TABLE jobb_historikk_arkiv
+            (
+                ID            BIGINT                                 NOT NULL PRIMARY KEY,
+                JOBB_ID       BIGINT                                 NOT NULL,
+                STATUS        VARCHAR(50)                            NOT NULL,
+                FEILMELDING   TEXT NULL,
+                OPPRETTET_TID TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL
+            )
+            """.trimIndent()
+        )
+    }
+
+    private fun opprettJobb(
+        connection: DBConnection,
+        status: JobbStatus,
+        nesteKjoring: LocalDateTime,
+        type: String
+    ): Long {
+        return connection.executeReturnKey(
+            """
+            INSERT INTO JOBB (status, type, neste_kjoring)
+            VALUES (?, ?, ?)
+            """.trimIndent()
+        ) {
+            setParams {
+                setEnumName(1, status)
+                setString(2, type)
+                setLocalDateTime(3, nesteKjoring)
+            }
+        }
+    }
+
+    private fun opprettHistorikk(connection: DBConnection, jobbId: Long, status: JobbStatus) {
+        connection.execute(
+            """
+            INSERT INTO JOBB_HISTORIKK (jobb_id, status, opprettet_tid)
+            VALUES (?, ?, ?)
+            """.trimIndent()
+        ) {
+            setParams {
+                setLong(1, jobbId)
+                setEnumName(2, status)
+                setLocalDateTime(3, LocalDateTime.now())
+            }
+        }
+    }
+
+    private fun antall(connection: DBConnection, query: String): Int {
+        return connection.queryFirst(query) {
+            setRowMapper {
+                it.getInt("antall")
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
…e kan skje for postmottak og oppgave. 
For å bøte på dette er det ønskelig å arkivere ferdigstilte og gamle jobber.

Ettersom dette krever at det finnes to nye tabeller: `jobb_arkiv` og `jobb_historikk_arkiv` vil ikke denne jobben gjøre noe før disse tabellene er opprettet.

Fått tips og råd av copilot underveis