### PR TITLE
støtte år 0001 - 10_000 i DaterangeParser

### DIFF
--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParser.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParser.kt
@@ -8,6 +8,11 @@ import java.time.temporal.ChronoField
 
 internal object DaterangeParser {
 
+    /**
+     * Skreddersydd DateTimeFormatter for å håndtere år fra 0001 til 10_000
+     * I Kelvin bruker vi år 0001 som Tid.MIN (f.eks. for å "nullstille" rettighetsperioden).
+     * Og fra bl.a. MEDL får vi år 10_000 som makstid (ingen sluttdato).
+     **/
     private val formatter = DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.NORMAL)
         .appendLiteral('-')

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParser.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParser.kt
@@ -8,7 +8,7 @@ import java.time.temporal.ChronoField
 
 internal object DaterangeParser {
 
-    private val formater = DateTimeFormatterBuilder()
+    private val formatter = DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.NORMAL)
         .appendLiteral('-')
         .appendValue(ChronoField.MONTH_OF_YEAR, 2)
@@ -17,7 +17,7 @@ internal object DaterangeParser {
         .toFormatter()
 
     internal fun toSQL(periode: Periode): String {
-        return "[${formater.format(periode.fom)},${formater.format(periode.tom)}]"
+        return "[${formatter.format(periode.fom)},${formatter.format(periode.tom)}]"
     }
 
     internal fun fromSQL(daterange: String): Periode {
@@ -28,12 +28,12 @@ internal object DaterangeParser {
         val upperDate = upper.dropLast(1)
         val upperEnd = upper.last()
 
-        var fom = formater.parse(lowerDate, LocalDate::from)
+        var fom = formatter.parse(lowerDate, LocalDate::from)
         if (lowerEnd == '(') {
             fom = fom.plusDays(1)
         }
 
-        var tom = formater.parse(upperDate, LocalDate::from)
+        var tom = formatter.parse(upperDate, LocalDate::from)
         if (upperEnd == ')') {
             tom = tom.minusDays(1)
         }

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParser.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParser.kt
@@ -2,11 +2,19 @@ package no.nav.aap.komponenter.dbconnect
 
 import no.nav.aap.komponenter.type.Periode
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.SignStyle
+import java.time.temporal.ChronoField
 
 internal object DaterangeParser {
 
-    private val formater = DateTimeFormatter.ofPattern("y-MM-dd")
+    private val formater = DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.NORMAL)
+        .appendLiteral('-')
+        .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+        .appendLiteral('-')
+        .appendValue(ChronoField.DAY_OF_MONTH, 2)
+        .toFormatter()
 
     internal fun toSQL(periode: Periode): String {
         return "[${formater.format(periode.fom)},${formater.format(periode.tom)}]"

--- a/dbconnect/src/test/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParserTest.kt
+++ b/dbconnect/src/test/kotlin/no/nav/aap/komponenter/dbconnect/DaterangeParserTest.kt
@@ -4,6 +4,7 @@ import no.nav.aap.komponenter.type.Periode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.Month
 
 internal class DaterangeParserTest {
 
@@ -54,6 +55,19 @@ internal class DaterangeParserTest {
 
         assertThat(periode.fom.minusDays(1)).isEqualTo(fom)
         assertThat(periode.tom.plusDays(1)).isEqualTo(tom)
+    }
+
+    @Test
+    fun `Kan parse Tid MIN og Tid MAKS`() {
+        val tidMin: LocalDate = LocalDate.of(1, Month.JANUARY, 1)
+        val tidMaks: LocalDate = LocalDate.of(2999, Month.JANUARY, 1)
+
+        val sqlPeriode = DaterangeParser.toSQL(Periode(tidMin, tidMaks))
+        assertThat(sqlPeriode).isEqualTo("[$tidMin,$tidMaks]")
+
+        val periode = DaterangeParser.fromSQL(sqlPeriode)
+        assertThat(periode.fom).isEqualTo(tidMin)
+        assertThat(periode.tom).isEqualTo(tidMaks)
     }
 
     @Test


### PR DESCRIPTION
Dette sikrer at vi håndterer både interne datoer (Tid.MIN = `01-01-0001`, Tid.MAX = `01-01-2999`) og dato fra MEDL som bruker år 10_000 som "maks dato" (ref. PR https://github.com/navikt/aap-kelvin-komponenter/pull/242)