### PR TITLE
fix(motor): replace MultiGauge with AtomicLong gauges to fix DuplicateLabelsException

### DIFF
--- a/motor/src/main/kotlin/no/nav/aap/motor/Motor.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/Motor.kt
@@ -1,8 +1,7 @@
 package no.nav.aap.motor
 
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.MultiGauge
-import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.dbconnect.transaction
@@ -22,7 +21,9 @@ import java.util.*
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import javax.sql.DataSource
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration
@@ -147,9 +148,23 @@ public class MotorImpl(
 
     private inner class Forbrenningskammer(private val dataSource: DataSource) : Runnable {
         private val log = LoggerFactory.getLogger(Forbrenningskammer::class.java)
-        private val aktivJobbGauge = MultiGauge.builder("motor_siste_plukk_timestamp_seconds")
-            .tag("forbrenningskammer", forbrenningskammerId.getAndIncrement().toString())
-            .register(prometheus)
+        private val kammerId = forbrenningskammerId.getAndIncrement().toString()
+
+        // Én AtomicLong per jobb-type, registrert én gang i prometheus for å unngå DuplicateLabelsException
+        private val sistePlukketTimestamps = ConcurrentHashMap<String, AtomicLong>()
+
+        private fun oppdaterSistePlukk(jobbType: String) {
+            sistePlukketTimestamps
+                .getOrPut(jobbType) {
+                    AtomicLong(Instant.now().epochSecond).also { tidspunkt ->
+                        Gauge.builder("motor_siste_plukk_timestamp_seconds") { tidspunkt.get().toDouble() }
+                            .tag("forbrenningskammer", kammerId)
+                            .tag("jobb_type", jobbType)
+                            .register(prometheus)
+                    }
+                }
+                .set(Instant.now().epochSecond)
+        }
 
         override fun run() {
             while (!stopped) {
@@ -172,18 +187,8 @@ public class MotorImpl(
                             * timestamp(motor_siste_plukk_timestamp_seconds) - motor_siste_plukk_timestamp_seconds
                             **/
 
-                            aktivJobbGauge.register(
-                                listOfNotNull(plukketJobb)
-                                    .map { jobbInput ->
-                                        MultiGauge.Row.of(
-                                            Tags.of("jobb_type", jobbInput.type()),
-                                            Instant.now().epochSecond
-                                        )
-                                    },
-                                true,
-                            )
-
                             if (plukketJobb != null) {
+                                oppdaterSistePlukk(plukketJobb.type())
                                 log.info("Plukket jobb $plukketJobb.")
                                 val behandlingId = plukketJobb.behandlingIdOrNull()
                                 val sakId = plukketJobb.sakIdOrNull()
@@ -208,7 +213,9 @@ public class MotorImpl(
                     log.error("Feil under plukking av jobber", exception)
                 }
                 log.debug("Ingen flere jobber å plukke, hviler litt")
-                aktivJobbGauge.register(setOf(), true)
+                // Nullstill til nå slik at query-en viser ~0 når kammeret er ledig
+                val nå = Instant.now().epochSecond
+                sistePlukketTimestamps.values.forEach { it.set(nå) }
                 if (!stopped) {
                     Thread.sleep(500)
                 }

--- a/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/MotorTest.kt
@@ -16,8 +16,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.slf4j.LoggerFactory
+import java.time.Instant
 import java.time.LocalDateTime
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
 
 private val logger = LoggerFactory.getLogger(MotorTest::class.java)
@@ -274,6 +277,72 @@ class MotorTest {
             }
         }
         assertThat(verdier).isEqualTo(verdier.distinct()).withFailMessage("Skal ikke ha duplikate verdier i test_table-tabellen - da har samme jobb blitt plukket og kjørt flere ganger")
+        motor.stop()
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    fun `metric viser tidspunkt for plukk mens jobb kjøres, og nullstilles til nå når kammeret er ledig`() {
+        val jobbStartet = CountDownLatch(1)
+        val jobbKanAvslutte = CountDownLatch(1)
+
+        val langJobb = object : Jobb {
+            override fun konstruer(connection: DBConnection) = object : JobbUtfører {
+                override fun utfør(input: JobbInput) {
+                    jobbStartet.countDown()
+                    jobbKanAvslutte.await(10, TimeUnit.SECONDS)
+                }
+            }
+            override fun type() = "test.lang.jobb"
+            override fun navn() = "lang jobb"
+            override fun beskrivelse() = "en lang jobb for test"
+        }
+
+        val prometheus = SimpleMeterRegistry()
+        val motor = Motor(
+            dataSource = dataSource,
+            antallKammer = 1,
+            jobber = listOf(langJobb),
+            prometheus = prometheus,
+        )
+
+        dataSource.transaction {
+            JobbRepository(it).leggTil(JobbInput(langJobb))
+        }
+        motor.start()
+
+        assertThat(jobbStartet.await(10, TimeUnit.SECONDS)).isTrue()
+
+        // Mens jobben kjøres: gauge er satt til tidspunktet jobben ble plukket (≤ nå)
+        val gaugeUnderKjøring = prometheus.get("motor_siste_plukk_timestamp_seconds")
+            .tag("jobb_type", "test.lang.jobb")
+            .gauge()
+            .value()
+        assertThat(gaugeUnderKjøring).isGreaterThan(0.0)
+        assertThat(gaugeUnderKjøring).isLessThanOrEqualTo(Instant.now().epochSecond.toDouble())
+
+        // Slipp jobben og vent til kammeret er ledig igjen
+        jobbKanAvslutte.countDown()
+
+        val deadline = Instant.now().plusSeconds(10)
+        while (Instant.now().isBefore(deadline)) {
+            val diff = Instant.now().epochSecond - prometheus.get("motor_siste_plukk_timestamp_seconds")
+                .tag("jobb_type", "test.lang.jobb")
+                .gauge()
+                .value()
+                .toLong()
+            if (diff <= 2) break
+            Thread.sleep(100)
+        }
+
+        // Etter at kammeret er ledig: gauge er nullstilt til nå, så differansen er ≈ 0
+        val gaugeEtterIdle = prometheus.get("motor_siste_plukk_timestamp_seconds")
+            .tag("jobb_type", "test.lang.jobb")
+            .gauge()
+            .value()
+        assertThat(Instant.now().epochSecond - gaugeEtterIdle.toLong())
+            .isLessThanOrEqualTo(2)
+
         motor.stop()
     }
 


### PR DESCRIPTION
 MultiGauge.register(..., overwrite=true) had a race condition where a new
 gauge was briefly added to the Prometheus registry before the old one was
 removed. If a scrape hit during that window, it threw DuplicateLabelsException
 for metric "motor_siste_plukk_timestamp_seconds".

 Fixed by registering one Gauge per (forbrenningskammer, jobb_type) backed by
 an AtomicLong. The value is updated atomically on each pick, and reset to
 Instant.now() when the chamber goes idle — preserving the Grafana query
 behavior (timestamp(metric) - metric ≈ job duration while running, ≈ 0 when idle).
