### PR TITLE
AAP-2194 Få tidslinje ved ifNotEmpty

### DIFF
--- a/tidslinje/src/main/kotlin/no/nav/aap/komponenter/tidslinje/Tidslinje.kt
+++ b/tidslinje/src/main/kotlin/no/nav/aap/komponenter/tidslinje/Tidslinje.kt
@@ -754,8 +754,8 @@ public inline fun <T> Tidslinje<T>.ifEmpty(defaultValue: () -> Tidslinje<T>): Ti
     return if (isEmpty()) defaultValue() else this
 }
 
-public inline fun <T> Tidslinje<T>.ifNotEmpty(defaultValue: () -> Tidslinje<T>): Tidslinje<T> {
-    return if (isNotEmpty()) defaultValue() else this
+public inline fun <T> Tidslinje<T>.ifNotEmpty(defaultValue: (Tidslinje<T>) -> Tidslinje<T>): Tidslinje<T> {
+    return if (isNotEmpty()) defaultValue(this) else this
 }
 
 /** Lag tidslinje basert på verdiene ved å knytte dem til perioder. Verdier lenger ut


### PR DESCRIPTION
Når man har en chain
```kotlin
    foo
    .bar()
    .ifNotEmpty { ... }
    .baz()
```
Så har man ingen måte i body til ifNotEmpty til å se på tidslinjen. Sender derfor med tidslinjen som parameter.