### PR TITLE
AAP-2194 Introduser Tidspunkt for å få postgres-vennlige Instants

### DIFF
--- a/dbconnect/build.gradle.kts
+++ b/dbconnect/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(libs.slf4j.api)
+    implementation(project(":verdityper"))
 
     implementation(libs.opentelemetry.annotations)
     implementation(kotlin("reflect"))

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Params.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Params.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.komponenter.dbconnect
 
 import no.nav.aap.komponenter.type.Periode
+import no.nav.aap.komponenter.verdityper.Tidspunkt
 import java.math.BigDecimal
 import java.sql.Connection
 import java.sql.Date
@@ -86,6 +87,10 @@ public class Params internal constructor(
 
     public fun setInstant(index: Int, instant: Instant?) {
         preparedStatement.setTimestamp(index, instant?.let(Timestamp::from))
+    }
+
+    public fun setTidspunkt(index: Int, tidspunkt: Tidspunkt?) {
+        preparedStatement.setTimestamp(index, tidspunkt?.let { Timestamp.from(it.asInstant) })
     }
 
     public fun setProperties(index: Int, properties: Properties?) {

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Row.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Row.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.komponenter.dbconnect
 
 import no.nav.aap.komponenter.type.Periode
+import no.nav.aap.komponenter.verdityper.Tidspunkt
 import java.math.BigDecimal
 import java.sql.Date
 import java.sql.ResultSet
@@ -218,6 +219,15 @@ public class Row internal constructor(private val resultSet: ResultSet) {
 
     public fun getInstant(columnLabel: String): Instant {
         return requireNotNull(getInstantOrNull(columnLabel)) { "Null-value for column label $columnLabel." }
+    }
+
+    public fun getTidspunktOrNull(columnLabel: String): Tidspunkt? {
+        val timestamp = resultSet.getTimestamp(columnLabel) ?: return null
+        return Tidspunkt.ofInstant(timestamp.toInstant())
+    }
+
+    public fun getTidspunkt(columnLabel: String): Tidspunkt {
+        return requireNotNull(getTidspunktOrNull(columnLabel)) { "Null-value for column label $columnLabel." }
     }
 
     public fun getPropertiesOrNull(columnLabel: String): Properties? {

--- a/dbconnect/src/test/kotlin/no/nav/aap/komponenter/dbconnect/ParamsOgRowTest.kt
+++ b/dbconnect/src/test/kotlin/no/nav/aap/komponenter/dbconnect/ParamsOgRowTest.kt
@@ -2,6 +2,7 @@ package no.nav.aap.komponenter.dbconnect
 
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.komponenter.type.Periode
+import no.nav.aap.komponenter.verdityper.Tidspunkt
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.TemporalUnitWithinOffset
 import org.junit.jupiter.api.AutoClose
@@ -378,6 +379,33 @@ internal class ParamsOgRowTest {
             }
         }
     }
+
+    @Test
+    fun `Skriver og leser Tidspunkt og null-verdi riktig`() {
+        val tidspunkt = Tidspunkt.parse("2016-08-12T09:38:14.123456Z")
+        dataSource.transaction { connection ->
+            connection.execute(
+                """
+                    INSERT INTO TEST_INSTANT (TEST, TEST_NULL)
+                    VALUES (?, ?)
+                """.trimMargin()
+            ) {
+                setParams {
+                    setTidspunkt(1, tidspunkt)
+                    setTidspunkt(2, null)
+                }
+            }
+            connection.queryFirst("SELECT * FROM TEST_INSTANT") {
+                setRowMapper { row ->
+                    assertThat(row.getTidspunktOrNull("TEST")).isEqualTo(tidspunkt)
+                    assertThat(row.getTidspunkt("TEST")).isEqualTo(tidspunkt)
+                    assertThat(row.getTidspunktOrNull("TEST_NULL")).isNull()
+                    assertThrows<IllegalArgumentException> { row.getInstant("TEST_NULL") }
+                }
+            }
+        }
+    }
+
 
     @Test
     fun `Skriver og leser med listeparametre`() {

--- a/verdityper/build.gradle.kts
+++ b/verdityper/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":dbconnect"))
     implementation(libs.jackson.annotations)
     testImplementation(project(":json"))
     testImplementation(libs.junit.jupiter.api)

--- a/verdityper/src/main/kotlin/no/nav/aap/komponenter/verdityper/Tid.kt
+++ b/verdityper/src/main/kotlin/no/nav/aap/komponenter/verdityper/Tid.kt
@@ -2,8 +2,11 @@ package no.nav.aap.komponenter.verdityper
 
 import java.time.LocalDate
 import java.time.Month
+import java.time.ZoneId
 
 public object Tid {
     public val MIN: LocalDate = LocalDate.of(1, Month.JANUARY, 1)
     public val MAKS: LocalDate = LocalDate.of(2999, Month.JANUARY, 1)
+
+    public val norskTidssone: ZoneId = ZoneId.of("Europe/Oslo")
 }

--- a/verdityper/src/main/kotlin/no/nav/aap/komponenter/verdityper/Tidspunkt.kt
+++ b/verdityper/src/main/kotlin/no/nav/aap/komponenter/verdityper/Tidspunkt.kt
@@ -1,0 +1,123 @@
+package no.nav.aap.komponenter.verdityper
+
+import com.fasterxml.jackson.annotation.JsonValue
+import no.nav.aap.komponenter.verdityper.Tid.norskTidssone
+import java.io.Serializable
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.time.temporal.Temporal
+import java.time.temporal.TemporalAdjuster
+import java.time.temporal.TemporalAmount
+import java.time.temporal.TemporalField
+import java.time.temporal.TemporalQuery
+import java.time.temporal.TemporalUnit
+import java.time.temporal.ValueRange
+
+/** Et tidspunkt, tilsvarende Javas [instant][java.time.Instant], men begrenset til verdier som Postgres kan lagre.
+ *
+ * Javas [Instant][java.time.Instant] kan lagre nanosekunder, mens Postgres' timestamp kan lagre mikrosekunder. Denne
+ * klassen skal fungere tilsvarende som en Instant, men bare med mikrosekunder, slik at vi får
+ * 1-til-1 mellom kode og database.
+ */
+public class Tidspunkt
+private constructor(
+    @JsonValue public val asInstant: Instant,
+) : Temporal by asInstant,
+    TemporalAdjuster,
+    Comparable<Tidspunkt>,
+    Serializable by asInstant {
+
+    init {
+        require(asInstant.truncatedTo(unit) == asInstant) {
+            """Privat konstruktør for Tidspunkt kalt med instant ($asInstant) som mangler trunkering til microsekunder."""
+        }
+        require(MIN_AS_INSTANT <= asInstant) {
+            """Privat konstruktør for Tidspunkt kalt med instant ($asInstant) som tidligere enn MIN-tidspunktet ($MIN_AS_INSTANT)."""
+        }
+        require(asInstant <= MAX_AS_INSTANT) {
+            """Privat konstruktør for Tidspunkt kalt med instant ($asInstant) som senere enn MAX-tidspunktet ($MAX_AS_INSTANT)."""
+        }
+    }
+
+    public companion object {
+        private val unit: ChronoUnit = ChronoUnit.MICROS
+
+        /* Dette tilsvarer Postgres' min og max. Kan vurdere å harmonisere med Tid.MIN og Tid.MAKS. */
+        private val MIN_AS_INSTANT = Instant.parse("-4713-10-16T23:00:00.000000Z")
+        private val MAX_AS_INSTANT = Instant.parse("+294276-12-31T22:59:59.999999Z")
+
+        public fun now(clock: Clock = Clock.systemDefaultZone()): Tidspunkt =
+            ofInstant(Instant.now(clock))
+
+        public fun ofInstant(instant: Instant): Tidspunkt =
+            Tidspunkt(instant.truncatedTo(unit).coerceIn(MIN_AS_INSTANT, MAX_AS_INSTANT))
+
+        public fun ofTemporal(temporal: Temporal): Tidspunkt =
+            ofInstant(Instant.from(temporal))
+
+        public fun parse(text: String): Tidspunkt =
+            ofInstant(Instant.parse(text))
+
+        public fun ofLocalDateTimeNorskTid(tidspunkt: LocalDateTime): Tidspunkt =
+            ofInstant(tidspunkt.atZone(norskTidssone).toInstant())
+    }
+
+    public fun toZonedDateTimeNorskTid(): ZonedDateTime =
+        asInstant.atZone(norskTidssone)
+
+    public fun toLocalDateTimeNorskTid(): LocalDateTime =
+        toZonedDateTimeNorskTid().toLocalDateTime()
+
+    public fun toLocalDateNorskTid(): LocalDate =
+        toZonedDateTimeNorskTid().toLocalDate()
+
+    public fun toLocalTimeNorskTid(): LocalTime =
+        toZonedDateTimeNorskTid().toLocalTime()
+
+    override fun toString(): String = asInstant.toString()
+
+    override fun compareTo(other: Tidspunkt): Int = this.asInstant.compareTo(other.asInstant)
+
+    override fun equals(other: Any?): Boolean = when (other) {
+        is Tidspunkt -> this.asInstant == other.asInstant
+        else -> false
+    }
+
+    override fun hashCode(): Int = asInstant.hashCode()
+
+    override fun isSupported(field: TemporalField?): Boolean = asInstant.isSupported(field)
+
+    override fun isSupported(unit: TemporalUnit?): Boolean = asInstant.isSupported(unit)
+
+    override fun range(field: TemporalField?): ValueRange? = asInstant.range(field)
+
+    override fun get(field: TemporalField?): Int = asInstant.get(field)
+
+    override fun <R> query(query: TemporalQuery<R?>?): R? = asInstant.query(query)
+
+    override fun with(adjuster: TemporalAdjuster): Tidspunkt =
+        ofInstant(asInstant.with(adjuster))
+
+    override fun with(field: TemporalField, newValue: Long): Tidspunkt =
+        ofInstant(asInstant.with(field, newValue))
+
+    override fun plus(amount: TemporalAmount): Tidspunkt =
+        ofInstant(asInstant.plus(amount))
+
+    override fun plus(amountToAdd: Long, unit: TemporalUnit): Tidspunkt =
+        ofInstant(asInstant.plus(amountToAdd, unit))
+
+    override fun minus(amount: TemporalAmount?): Tidspunkt =
+        ofInstant(asInstant.minus(amount))
+
+    override fun minus(amountToSubtract: Long, unit: TemporalUnit): Tidspunkt =
+        ofInstant(asInstant.minus(amountToSubtract, unit))
+
+    override fun adjustInto(temporal: Temporal): Tidspunkt =
+        ofTemporal(asInstant.adjustInto(temporal))
+}

--- a/verdityper/src/test/kotlin/no/nav/aap/komponenter/verdityper/TidspunktTest.kt
+++ b/verdityper/src/test/kotlin/no/nav/aap/komponenter/verdityper/TidspunktTest.kt
@@ -1,0 +1,39 @@
+package no.nav.aap.komponenter.verdityper
+
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class TidspunktTest {
+    @Test
+    fun `roundtrip json`() {
+        val tidspunkt = Tidspunkt.parse("2021-04-24T13:43:02.123456Z")
+
+        val json = DefaultJsonMapper.toJson(tidspunkt)
+        assertThat(json).isEqualTo("\"2021-04-24T13:43:02.123456Z\"")
+
+        val deserialized = DefaultJsonMapper.fromJson<Tidspunkt>(json)
+
+        assertThat(deserialized).isEqualTo(tidspunkt)
+        assertThat(deserialized.asInstant)
+            .isEqualTo(Instant.parse("2021-04-24T13:43:02.123456Z"))
+    }
+
+    @Test
+    fun `trunkerer nanosekunder`() {
+        val instant = Instant.parse("2021-04-24T13:43:02.123456789Z")
+        val tidspunkt = Tidspunkt.ofInstant(instant)
+
+        assertThat(tidspunkt)
+            .isEqualTo(Tidspunkt.parse("2021-04-24T13:43:02.123456Z"))
+    }
+
+    @Test
+    fun `instant som kun er forskjellige i nanosekunder blir like Tidspunkt`() {
+        val instant1 = Instant.parse("2021-04-24T13:43:02.123456111Z")
+        val instant2 = Instant.parse("2021-04-24T13:43:02.123456222Z")
+        assertThat(Tidspunkt.ofInstant(instant1))
+            .isEqualTo(Tidspunkt.ofInstant(instant2))
+    }
+}


### PR DESCRIPTION
Formålet er å ha en datatype (Tidspunkt) som ivaretar de behovene som 
java.time.Instant pleier å ivareta, men som også kan lagres ned i 
en tabell uten informasjonstap.

Tidspunkt har
- Vi har kun mikrosekunder (i stede for Instants nanosekunder)
- MIN og MAX er begrenset til postgres sin min/maks

Har også hjelpemetoder for å konvertere til norsk tid.

Basert på https://github.com/navikt/pensjon-etterlatte-saksbehandling/blob/main/libs/saksbehandling-common/src/main/kotlin/tidspunkt/Tidspunkt.kt