### PR TITLE
AAP-2194 Fjern unødvendig typeakrobatikk

### DIFF
--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Row.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Row.kt
@@ -37,15 +37,9 @@ public class Row internal constructor(private val resultSet: ResultSet) {
         return enumValueOf(getString(columnLabel))
     }
 
-    /**
-     * Siden enumValueOf ikke kan forholde seg til nullable typer,
-     * og compileren ikke kan forstå at typen ikke er null når databaseverdien er null,
-     * så innføres [T] for å gi compileren hint om at returtypen kan være null
-     */
-    public inline fun <reified T, reified E> getEnumOrNull(columnLabel: String): E?
-            where T : E?,
-                  E : Enum<E> {
-        return getStringOrNull(columnLabel)?.let<String, E>(::enumValueOf)
+    public inline fun <reified T: Enum<T>> getEnumOrNull(columnLabel: String): T? {
+        val valueAsString = getStringOrNull(columnLabel) ?: return null
+        return enumValueOf<T>(valueAsString)
     }
 
     public fun getInt(columnLabel: String): Int {

--- a/dbconnect/src/test/kotlin/no/nav/aap/komponenter/dbconnect/ParamsOgRowTest.kt
+++ b/dbconnect/src/test/kotlin/no/nav/aap/komponenter/dbconnect/ParamsOgRowTest.kt
@@ -100,9 +100,9 @@ internal class ParamsOgRowTest {
             }
             connection.queryFirst("SELECT * FROM TEST_ENUM") {
                 setRowMapper { row ->
-                    assertThat(row.getEnumOrNull<TestEnum?, TestEnum>("TEST")).isEqualTo(TestEnum.TEST)
+                    assertThat(row.getEnumOrNull<TestEnum>("TEST")).isEqualTo(TestEnum.TEST)
                     assertThat(row.getEnum<TestEnum>("TEST")).isEqualTo(TestEnum.TEST)
-                    assertThat(row.getEnumOrNull<TestEnum?, TestEnum>("TEST_NULL")).isNull()
+                    assertThat(row.getEnumOrNull<TestEnum>("TEST_NULL")).isNull()
                     assertThrows<IllegalArgumentException> { row.getEnum<TestEnum>("TEST_NULL") }
                 }
             }


### PR DESCRIPTION
Om noen konsumenter av APIet spesifiserer typene, så vil de få kompileringsfeil. Så venter med å merge til jeg også har tid til å oppdatere konsumenter.