### PR TITLE
AAP-2194 Ikke bruk java.sql.Timestamp

### DIFF
--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Params.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Params.kt
@@ -12,6 +12,7 @@ import java.sql.Types
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.*
 
 public class Params internal constructor(
@@ -91,7 +92,7 @@ public class Params internal constructor(
     }
 
     public fun setTidspunkt(index: Int, tidspunkt: Tidspunkt?) {
-        preparedStatement.setTimestamp(index, tidspunkt?.let { Timestamp.from(it.asInstant) })
+        preparedStatement.setObject(index, tidspunkt?.asInstant?.atOffset(ZoneOffset.UTC))
     }
 
     public fun setProperties(index: Int, properties: Properties?) {

--- a/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Row.kt
+++ b/dbconnect/src/main/kotlin/no/nav/aap/komponenter/dbconnect/Row.kt
@@ -10,6 +10,7 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.*
 import kotlin.reflect.KClass
 
@@ -227,8 +228,8 @@ public class Row internal constructor(private val resultSet: ResultSet) {
     }
 
     public fun getTidspunktOrNull(columnLabel: String): Tidspunkt? {
-        val timestamp = resultSet.getTimestamp(columnLabel) ?: return null
-        return Tidspunkt.ofInstant(timestamp.toInstant())
+        val offsetDateTime = resultSet.getObject(columnLabel, OffsetDateTime::class.java) ?: return null
+        return Tidspunkt.ofInstant(offsetDateTime.toInstant())
     }
 
     public fun getTidspunkt(columnLabel: String): Tidspunkt {


### PR DESCRIPTION
java.sql.Timestamp er basert på det gamle java.time-systemet. postgres-jdbc har støtte for å lese `timestamp` som OffsetDateTime og `timestamptz` som LocalDateTime.

Endrer ikke her på koden for Instant og LocalDateTime, for de er mye brukt, og har ikke undersøkt om det er noen konsekvenser ved å skrive de om til å ikke bruke Timestamp.

Men den nye klassen Tidspunkt er ikke tatt i bruk enda, så den kan skrives om.