### PR TITLE
Den gamle retry-backoff-støtten var egentlig hadde en del svakheter d…

### DIFF
--- a/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
@@ -154,6 +154,12 @@ public class JobbRepository(private val connection: DBConnection) {
     }
 
     public fun plukkJobbV2(): JobbInput? {
+        /* `kjorbar` alene er IKKE nok til å avgjøre om jobben skal plukkes nå: en jobb som feiler
+         * med `retryBackoffTid` beholder `kjorbar = true` (den eier fortsatt eksklusivitets-slotten
+         * for sin (sak_id, behandling_id, type)-gruppe), men `neste_kjoring` flyttes frem i tid.
+         * Uten denne sjekken ville jobben blitt plukket på nytt umiddelbart, uten å respektere
+         * backoff-tiden. Se `skjedulerEkskluderendeJobber` for hvordan eksklusivitet håndteres.
+         */
         val query = """
             select jobb.id,
                    jobb.type,
@@ -171,12 +177,16 @@ public class JobbRepository(private val connection: DBConnection) {
             from jobb
             where jobb.status = '${JobbStatus.KLAR.name}'
             and jobb.kjorbar
+            and jobb.neste_kjoring <= ?
             order by jobb.neste_kjoring
             for update skip locked
             limit 1
         """.trimIndent()
 
         val plukketJobb = connection.queryFirstOrNull(query) {
+            setParams {
+                setLocalDateTime(1, LocalDateTime.now())
+            }
             setRowMapper { row ->
                 JobbInputParser.mapJobb(row)
             }
@@ -218,21 +228,58 @@ public class JobbRepository(private val connection: DBConnection) {
                 at å sette kjorbar := true er en idempotent operasjon, og vi får ikke
                 feil hvis to transaksjoner gjør samme endring – uavhengig av hvor lang
                 tid det er mellom endringene.
+
+                Designprinsipp: `kjorbar = true` betyr at raden eier eksklusivitets-slotten
+                for sin (sak_id, behandling_id, type)-gruppe helt til jobben når en terminal
+                tilstand (FERDIG, eller FEILET etter maks antall forsøk). En backoff-retry
+                (se `markerSomFeilet`) flytter kun `neste_kjoring` fremover i tid og
+                rører ALDRI `kjorbar` – jobben beholder altså slotten sin under hele
+                ventetiden. `plukkJobbV2` respekterer `neste_kjoring` før den plukker en
+                allerede-kjørbar rad på nytt.
+
+                Om en gruppe skal blokkeres for ny forfremmelse avgjøres derfor med en
+                RENDYRKET EKSISTENSSJEKK («finnes det en blokkerende rad i gruppen?»),
+                ikke ved å sammenligne `neste_kjoring` på tvers av gruppen slik den forrige
+                versjonen av denne spørringen gjorde. Det var nettopp den sammenligningen
+                som ga et race: når en jobb X sin `neste_kjoring` ble flyttet forbi et
+                søsken Y sin, "vant" Y `distinct on`-sorteringen og ble forfremmet selv om
+                X fortsatt var aktiv. Eksistenssjekken er uavhengig av X sin `neste_kjoring`,
+                så Y kan aldri forfremmes mens X (uansett tidspunkt) fortsatt er
+                status='KLAR' og kjorbar=true.
+
+                FEILET (terminal, maks forsøk nådd) skal fortsatt blokkere gruppen inntil
+                en saksbehandler/ops manuelt løser den (se RetryFeiledeJobberRepository),
+                for å bevare rekkefølge-garantien – men en FEILET-rad skal aldri selv bli
+                forfremmet (den kan uansett ikke plukkes av `plukkJobbV2`, som krever
+                status='KLAR').
          */
         val query = """
-            with neste_ekskluderende_jobb as (
-                select distinct on (sak_id, behandling_id, type) id, status
+            with grupper_blokkert as (
+                select distinct sak_id, behandling_id, type
                 from jobb
-                where status IN ('${JobbStatus.FEILET.name}', '${JobbStatus.KLAR.name}')
-                  and (sak_id is not null or (sak_id is null and behandling_id is not null))
-                order by sak_id, behandling_id, type, neste_kjoring
+                where status = '${JobbStatus.FEILET.name}'
+                   or (status = '${JobbStatus.KLAR.name}' and kjorbar)
+            ),
+            neste_ekskluderende_jobb as (
+                select distinct on (j.sak_id, j.behandling_id, j.type) j.id
+                from jobb j
+                where j.status = '${JobbStatus.KLAR.name}'
+                  and not j.kjorbar
+                  and (j.sak_id is not null or (j.sak_id is null and j.behandling_id is not null))
+                  and j.neste_kjoring <= ?
+                  and not exists (
+                      select 1
+                      from grupper_blokkert g
+                      where g.type = j.type
+                        and g.sak_id is not distinct from j.sak_id
+                        and g.behandling_id is not distinct from j.behandling_id
+                  )
+                order by j.sak_id, j.behandling_id, j.type, j.neste_kjoring
             )
             update jobb
             set kjorbar = true
             from neste_ekskluderende_jobb
             where jobb.id = neste_ekskluderende_jobb.id
-            and jobb.neste_kjoring <= ?
-            and not jobb.kjorbar
         """.trimIndent()
 
         return connection.executeReturnUpdated(query) {
@@ -309,7 +356,7 @@ public class JobbRepository(private val connection: DBConnection) {
                 }
             }
         } else if (jobbInput.jobb.retryBackoffTid != null && jobbId != null) {
-           val nesteKjøreTidspunkt = jobbInput.nesteKjøringTidspunkt().plus(jobbInput.jobb.retryBackoffTid)
+           val nesteKjøreTidspunkt = LocalDateTime.now().plus(jobbInput.jobb.retryBackoffTid)
             settNesteKjøring(jobbId, nesteKjøreTidspunkt)
         }
 

--- a/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/JobbRepository.kt
@@ -231,7 +231,7 @@ public class JobbRepository(private val connection: DBConnection) {
 
                 Designprinsipp: `kjorbar = true` betyr at raden eier eksklusivitets-slotten
                 for sin (sak_id, behandling_id, type)-gruppe helt til jobben når en terminal
-                tilstand (FERDIG, eller FEILET etter maks antall forsøk). En backoff-retry
+                tilstand (FERDIG). En backoff-retry
                 (se `markerSomFeilet`) flytter kun `neste_kjoring` fremover i tid og
                 rører ALDRI `kjorbar` – jobben beholder altså slotten sin under hele
                 ventetiden. `plukkJobbV2` respekterer `neste_kjoring` før den plukker en
@@ -247,7 +247,7 @@ public class JobbRepository(private val connection: DBConnection) {
                 så Y kan aldri forfremmes mens X (uansett tidspunkt) fortsatt er
                 status='KLAR' og kjorbar=true.
 
-                FEILET (terminal, maks forsøk nådd) skal fortsatt blokkere gruppen inntil
+                FEILET (maks forsøk nådd) skal fortsatt blokkere gruppen inntil
                 en saksbehandler/ops manuelt løser den (se RetryFeiledeJobberRepository),
                 for å bevare rekkefølge-garantien – men en FEILET-rad skal aldri selv bli
                 forfremmet (den kan uansett ikke plukkes av `plukkJobbV2`, som krever

--- a/motor/src/main/kotlin/no/nav/aap/motor/JobbSpesifikasjon.kt
+++ b/motor/src/main/kotlin/no/nav/aap/motor/JobbSpesifikasjon.kt
@@ -20,9 +20,12 @@ public sealed interface JobbSpesifikasjon {
         get() = 3
 
     /**
-     * Backoff-tid ved en feilet jobb - kan kun settes på selvstendige jobber som ikke må kjøres i sekvens med andre
-     * F.eks. skal ikke prosesserBehandlingJobb og lignende som er en del av innebygd orkestrering bruke denne.
-     * Iverksetting til utbetaling har behov da det er nyttig å kunne rekjøre senere.
+     * Backoff-tid ved en feilet jobb. Kan brukes både på selvstendige jobber og på jobber som
+     * inngår i en eksklusivitetsgruppe (samme sak_id/behandling_id/type).
+     *
+     * For jobber i en eksklusivitetsgruppe: jobben beholder sin plass i køen (kjorbar=true) mens
+     * den venter på backoff-tiden – ingen andre jobber i samme gruppe kan starte i mellomtiden.
+     * Se `JobbRepository.skjedulerEkskluderendeJobber` for detaljer om hvordan dette garanteres.
      */
     public val retryBackoffTid: Duration?
         get() = null

--- a/motor/src/test/kotlin/no/nav/aap/motor/JobbRepositoryTest.kt
+++ b/motor/src/test/kotlin/no/nav/aap/motor/JobbRepositoryTest.kt
@@ -167,6 +167,102 @@ class JobbRepositoryTest {
     }
 
     @Test
+    fun `skal ikke gjøre søsken-jobb i samme eksklusivitetsgruppe kjørbar mens en jobb venter på retryBackoffTid`() {
+        val sakId = 42L
+        val tidligst = LocalDateTime.now().minusDays(1)
+        val senest = LocalDateTime.now().minusHours(1)
+
+        dataSource.transaction { connection ->
+            val jobbRepository = JobbRepository(connection)
+            jobbRepository.leggTil(
+                JobbInput(AsynkronTullJobbUtfører).forSak(sakId).medNesteKjøring(tidligst)
+            )
+            jobbRepository.leggTil(
+                JobbInput(AsynkronTullJobbUtfører).forSak(sakId).medNesteKjøring(senest)
+            )
+        }
+
+        val ider = mutableListOf<Long>()
+        dataSource.transaction { connection ->
+            val testJobbRepository = TestJobbRepository(connection)
+            val jobber = testJobbRepository
+                .hentJobberAvTypeMedAttributter(AsynkronTullJobbUtfører.type, sakId, null)
+                .sortedBy { it.nesteKjøring() }
+            ider.addAll(jobber.map { it.jobbId() })
+        }
+        val xId = ider[0]
+        val yId = ider[1]
+
+        dataSource.transaction { connection ->
+            val jobbRepository = JobbRepository(connection)
+
+            // App1: skjedulerer og plukker X (den med tidligst neste_kjoring)
+            jobbRepository.skjedulerJobber()
+            val plukketX = jobbRepository.plukkJobbV2()
+            assertThat(plukketX).isNotNull
+            assertThat(plukketX!!.jobbId()).isEqualTo(xId)
+
+            // X feiler og settes i backoff - neste_kjoring flyttes forbi Y sin neste_kjoring
+            jobbRepository.markerSomFeilet(plukketX, IllegalStateException("simulert feil"))
+
+            // App2 (simulert): skjedulerer på nytt. Y skal IKKE bli forfremmet selv om
+            // X sin neste_kjoring nå er senere enn Y sin.
+            jobbRepository.skjedulerJobber()
+        }
+
+        dataSource.transaction { connection ->
+            val kjørbareRader = connection.queryList(
+                "select id, kjorbar from jobb where sak_id = ? order by id"
+            ) {
+                setParams { setLong(1, sakId) }
+                setRowMapper { row -> row.getLong("id") to row.getBoolean("kjorbar") }
+            }
+
+            val aktive = kjørbareRader.filter { it.second }
+            // Kun X skal fortsatt eie eksklusivitets-slotten, aldri begge samtidig.
+            assertThat(aktive).hasSize(1)
+            assertThat(aktive.single().first).isEqualTo(xId)
+
+            // Y skal fortsatt være blokkert (ikke kjørbar)
+            assertThat(kjørbareRader.first { it.first == yId }.second).isFalse()
+        }
+
+        dataSource.transaction { connection ->
+            val jobbRepository = JobbRepository(connection)
+            // Ingen jobb skal kunne plukkes nå: X er ikke forfalt (backoff), Y er ikke kjørbar
+            assertThat(jobbRepository.plukkJobbV2()).isNull()
+        }
+    }
+
+    @Test
+    fun `selvstendige jobber av samme type skal kunne være kjørbare samtidig`() {
+        val nå = LocalDateTime.now().minusMinutes(1)
+
+        dataSource.transaction { connection ->
+            val jobbRepository = JobbRepository(connection)
+            // To selvstendige jobber (uten sak_id/behandling_id) av samme type - skal IKKE
+            // behandles som en eksklusivitetsgruppe. Sikkerhetsnett-indeksen (UX_JOBB_EKSKLUSIV_AKTIV)
+            // må derfor ekskludere disse, ellers ville denne transaksjonen feilet med
+            // unique constraint violation.
+            jobbRepository.leggTil(JobbInput(AsynkronTullJobbUtfører).medNesteKjøring(nå))
+            jobbRepository.leggTil(JobbInput(AsynkronTullJobbUtfører).medNesteKjøring(nå))
+            jobbRepository.skjedulerJobber()
+        }
+
+        dataSource.transaction { connection ->
+            val kjørbareRader = connection.queryList(
+                "select id, kjorbar from jobb where type = ? and sak_id is null and behandling_id is null"
+            ) {
+                setParams { setString(1, AsynkronTullJobbUtfører.type) }
+                setRowMapper { row -> row.getBoolean("kjorbar") }
+            }
+
+            assertThat(kjørbareRader).hasSize(2)
+            assertThat(kjørbareRader).allMatch { it }
+        }
+    }
+
+    @Test
     fun `kan telle riktig antall jobber`() {
         val typer = listOf(TøysOgTullTestJobbUtfører, TullTestJobbUtfører, TøysTestJobbUtfører)
 

--- a/motor/src/test/resources/flyway/V0.1__modell.sql
+++ b/motor/src/test/resources/flyway/V0.1__modell.sql
@@ -22,7 +22,13 @@ CREATE INDEX IDX_JOBB_STATUS_NESTE_KJORING ON JOBB (STATUS, NESTE_KJORING);
 CREATE INDEX IDX_JOBB_NESTE_KJORING ON JOBB (NESTE_KJORING);
 CREATE INDEX IDX_JOBB_NESTE_KJORING_SAK_BEHANDLING ON JOBB (SAK_ID, BEHANDLING_ID, NESTE_KJORING);
 
--- Sikkerhetsnett: maks én aktiv (kjørbar) jobb per eksklusivitetsgruppe (sak_id, behandling_id, type).
+-- Sikkerhetsnett: maks én blokkerende jobb per eksklusivitetsgruppe (sak_id, behandling_id, type).
+-- «Blokkerende» speiler grupper_blokkert i skjedulerEkskluderendeJobber: status='FEILET' ELLER
+-- (status='KLAR' AND kjorbar). Begge deler må være med - en FEILET-rad beholder kjorbar=true
+-- (den røres aldri av markerSomFeilet), men mister STATUS='KLAR' og ville falt utenfor
+-- indeksen om FEILET ikke var inkludert. Da ville ikke databasen lenger håndheve at kun
+-- én rad kan eie eksklusivitets-slotten - sikkerhetsnettet ville hatt et hull nøyaktig i
+-- det tilfellet det skal fange opp (en bug i grupper_blokkert-sjekken).
 -- Bruker COALESCE til sentinelverdi (-1) fordi NULL != NULL i unike indekser i Postgres.
 -- VIKTIG: må begrenses til rader som faktisk inngår i en eksklusivitetsgruppe, altså der
 -- sak_id og/eller behandling_id er satt (samme betingelse som skjedulerEkskluderendeJobber).
@@ -32,7 +38,8 @@ CREATE INDEX IDX_JOBB_NESTE_KJORING_SAK_BEHANDLING ON JOBB (SAK_ID, BEHANDLING_I
 -- type til samme nøkkel (-1, -1, type), og indeksen ville feilaktig blokkere dem.
 -- Denne indeksen skal også legges til av konsumenter av dette biblioteket i egne migrasjoner.
 CREATE UNIQUE INDEX UX_JOBB_EKSKLUSIV_AKTIV ON JOBB (COALESCE(SAK_ID, -1), COALESCE(BEHANDLING_ID, -1), TYPE)
-    WHERE KJORBAR AND STATUS = 'KLAR' AND (SAK_ID IS NOT NULL OR BEHANDLING_ID IS NOT NULL);
+    WHERE (STATUS = 'FEILET' OR (STATUS = 'KLAR' AND KJORBAR))
+      AND (SAK_ID IS NOT NULL OR BEHANDLING_ID IS NOT NULL);
 
 CREATE TABLE JOBB_HISTORIKK
 (

--- a/motor/src/test/resources/flyway/V0.1__modell.sql
+++ b/motor/src/test/resources/flyway/V0.1__modell.sql
@@ -22,6 +22,18 @@ CREATE INDEX IDX_JOBB_STATUS_NESTE_KJORING ON JOBB (STATUS, NESTE_KJORING);
 CREATE INDEX IDX_JOBB_NESTE_KJORING ON JOBB (NESTE_KJORING);
 CREATE INDEX IDX_JOBB_NESTE_KJORING_SAK_BEHANDLING ON JOBB (SAK_ID, BEHANDLING_ID, NESTE_KJORING);
 
+-- Sikkerhetsnett: maks én aktiv (kjørbar) jobb per eksklusivitetsgruppe (sak_id, behandling_id, type).
+-- Bruker COALESCE til sentinelverdi (-1) fordi NULL != NULL i unike indekser i Postgres.
+-- VIKTIG: må begrenses til rader som faktisk inngår i en eksklusivitetsgruppe, altså der
+-- sak_id og/eller behandling_id er satt (samme betingelse som skjedulerEkskluderendeJobber).
+-- Selvstendige jobber (sak_id OG behandling_id er NULL) er ikke en eksklusivitetsgruppe -
+-- flere av samme type SKAL kunne være kjørbar=true samtidig. Uten denne begrensningen ville
+-- COALESCE(sak_id,-1), COALESCE(behandling_id,-1) kollapse alle selvstendige jobber av samme
+-- type til samme nøkkel (-1, -1, type), og indeksen ville feilaktig blokkere dem.
+-- Denne indeksen skal også legges til av konsumenter av dette biblioteket i egne migrasjoner.
+CREATE UNIQUE INDEX UX_JOBB_EKSKLUSIV_AKTIV ON JOBB (COALESCE(SAK_ID, -1), COALESCE(BEHANDLING_ID, -1), TYPE)
+    WHERE KJORBAR AND STATUS = 'KLAR' AND (SAK_ID IS NOT NULL OR BEHANDLING_ID IS NOT NULL);
+
 CREATE TABLE JOBB_HISTORIKK
 (
     ID            BIGSERIAL                              NOT NULL PRIMARY KEY,


### PR DESCRIPTION
…a den ikke kunne garantere for at samme jobb ble kjørt først dersom det finnes flere jobber med samme ekskluderingsgruppe (sakid, behandlingid, jobbtype). Dette smalt når vi gikk over til v2 av plukk fordi vi endte opp med å kunne kjøre flere av samme jobb samtidig og endte opp med uheldig race condition. Med denne løsningen skal dette tas høyde for. Usikker på om det påvirker ytelsen for skjedulerEkskluderendeJobber-metoden ettersom kompleksiteten er drastisk økt.

Har fått rikelig med hjelp av @navikt/copilot 