### PR TITLE
AAP-BAU Kan ikke sette tidssone til UTC på datasource når applikasjon…

### DIFF
--- a/dbtest/src/main/kotlin/no/nav/aap/komponenter/dbtest/TestDataSource.kt
+++ b/dbtest/src/main/kotlin/no/nav/aap/komponenter/dbtest/TestDataSource.kt
@@ -145,8 +145,6 @@ public class TestDataSource : AutoCloseable, DataSource {
 
                 minimumIdle = 0
                 maximumPoolSize = poolSize
-
-                connectionInitSql = "SET TIMEZONE TO 'UTC'"
             })
             logger.debug(
                 "Skapte tom Postgres-db med URL ${ds.jdbcUrl}. Brukernavn: ${postgres.username}. Db-navn: $dbName"


### PR DESCRIPTION
…en kjører i Europe/Oslo - da blir det diff på to timer mellom currentTimestamp og JDK sin now() - og sjekk på klokkeslett blir dermed feil